### PR TITLE
[#DCOM-164] ignoring @type phpdoc annotations

### DIFF
--- a/lib/Doctrine/Common/Annotations/AnnotationReader.php
+++ b/lib/Doctrine/Common/Annotations/AnnotationReader.php
@@ -69,7 +69,7 @@ class AnnotationReader implements Reader
         'Required' => true, 'Attribute' => true, 'Attributes' => true,
         'Target' => true, 'SuppressWarnings' => true,
         'ingroup' => true, 'code' => true, 'endcode' => true,
-        'package_version' => true, 'fixme' => true
+        'package_version' => true, 'fixme' => true, 'type' => true
     );
 
     /**

--- a/tests/Doctrine/Tests/Common/Annotations/AbstractReaderTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/AbstractReaderTest.php
@@ -374,6 +374,16 @@ abstract class AbstractReaderTest extends \PHPUnit_Framework_TestCase
         $ref = new \ReflectionClass('Doctrine\Tests\Common\Annotations\DCOM106');
         $reader->getClassAnnotations($ref);
     }
+
+    /**
+     * @group DCOM-164
+     */
+    public function testTypeAnnotation()
+    {
+        $reader = $this->getReader();
+        $class = new \ReflectionClass('Doctrine\Tests\Common\Annotations\DummyClassWithTypeAnnotation');
+        $this->assertCount(0, $reader->getPropertyAnnotations($class->getProperty('foo')));
+    }
     
     /**
      * @return AnnotationReader
@@ -552,6 +562,14 @@ class DummyClassWithEmail
 class DCOM106
 {
     
+}
+
+class DummyClassWithTypeAnnotation
+{
+    /**
+     * @type string
+     */
+    public $foo;
 }
 
 namespace Doctrine\Tests\Common\Annotations\Foo;


### PR DESCRIPTION
[Issue DCOM-164](http://www.doctrine-project.org/jira/browse/DCOM-164)

> phpDocumentor guys wrote their own PSR to define how to use phpdoc properly (https://github.com/phpDocumentor/phpDocumentor2/blob/develop/docs/PSR.md).
> They deprecate the @var annotation and recommend using @type instead.
> 
> The @type (phpdoc) annotation is not blacklisted/ignored by the AnnotationReader. Code that uses this annotation raises errors with Doctrine/Annotations.
> 
> @type should be blacklisted/ignored, but may that create BC breaks for users?

This PR contains test + fix
