### PR TITLE
A test that tries to set an array of values where keys may have numbers

### DIFF
--- a/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
@@ -1198,6 +1198,23 @@ DOCBLOCK;
         $parser = $this->createTestParser();
         $parser->parse('@Name(foo: "bar")');
     }
+    
+    public function testKeyHasNumber()
+    {
+        $parser = $this->createTestParser(); 
+        $parser->parse('@SettingsAnnotaion(foo="test", bar2="test")');   
+    }
+}
+
+/** @Annotation */
+class SettingsAnnotaion
+{
+    public $settings;    
+    
+    public function __construct($settings)
+    {
+        $this->settings = $settings;
+    }
 }
 
 /** @Annotation */


### PR DESCRIPTION
The test fails to pass because the lexer hits the constant check if the key has numeric values. Same code passes with doctrine/common 2.2.*
