### PR TITLE
Moving phpunit task from before_script to script in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,3 @@ php:
 
 before_script:
     - composer --prefer-source --dev install
-    - phpunit


### PR DESCRIPTION
As @stof said in #6, phpunit should be in `script`, and not in `before_script` in `.travis.yml`. Sorry about that :\
