### PR TITLE
Allow empty array notations

### DIFF
--- a/lib/Doctrine/Common/Annotations/DocParser.php
+++ b/lib/Doctrine/Common/Annotations/DocParser.php
@@ -982,6 +982,14 @@ final class DocParser
         $array = $values = array();
 
         $this->match(DocLexer::T_OPEN_CURLY_BRACES);
+
+        // If the array is empty, stop parsing and return.
+        if ($this->lexer->isNextToken(DocLexer::T_CLOSE_CURLY_BRACES)) {
+            $this->match(DocLexer::T_CLOSE_CURLY_BRACES);
+
+            return $array;
+        }
+
         $values[] = $this->ArrayEntry();
 
         while ($this->lexer->isNextToken(DocLexer::T_COMMA)) {

--- a/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
@@ -1198,6 +1198,18 @@ DOCBLOCK;
         $parser = $this->createTestParser();
         $parser->parse('@Name(foo: "bar")');
     }
+
+    /**
+     * Tests parsing empty arrays.
+     */
+    public function testEmptyArray()
+    {
+        $parser = $this->createTestParser();
+
+        $annots = $parser->parse('@Name({"foo": {}})');
+        $this->assertEquals(1, count($annots));
+        $this->assertEquals(array('foo' => array()), $annots[0]->value);
+    }
 }
 
 /** @Annotation */


### PR DESCRIPTION
This commit allows empty arrays to be parsed. It is based on https://github.com/doctrine/annotations/pull/5, but it adds a test on top of it.
