### PR TITLE
Fixed warnings (in PhpStorm) in tests

### DIFF
--- a/lib/Doctrine/Common/Annotations/DocParser.php
+++ b/lib/Doctrine/Common/Annotations/DocParser.php
@@ -19,11 +19,9 @@
 
 namespace Doctrine\Common\Annotations;
 
-use Closure;
 use ReflectionClass;
 use Doctrine\Common\Annotations\Annotation\Enum;
 use Doctrine\Common\Annotations\Annotation\Target;
-use Doctrine\Common\Annotations\Annotation\Attribute;
 use Doctrine\Common\Annotations\Annotation\Attributes;
 
 /**

--- a/tests/Doctrine/Tests/Common/Annotations/AbstractReaderTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/AbstractReaderTest.php
@@ -2,18 +2,9 @@
 
 namespace Doctrine\Tests\Common\Annotations;
 
-use Doctrine\Common\Annotations\DoctrineReader;
 use Doctrine\Common\Annotations\Annotation\IgnoreAnnotation;
-use Doctrine\Common\Annotations\Annotation\IgnorePhpDoc;
+use Doctrine\Common\Annotations\Annotation;
 use ReflectionClass, Doctrine\Common\Annotations\AnnotationReader;
-
-use Doctrine\Tests\Common\Annotations\DummyAnnotation;
-use Doctrine\Tests\Common\Annotations\Name;
-use Doctrine\Tests\Common\Annotations\DummyId;
-use Doctrine\Tests\Common\Annotations\DummyJoinTable;
-use Doctrine\Tests\Common\Annotations\DummyJoinColumn;
-use Doctrine\Tests\Common\Annotations\DummyColumn;
-use Doctrine\Tests\Common\Annotations\DummyGeneratedValue;
 
 require_once __DIR__ . '/TopLevelAnnotation.php';
 
@@ -94,7 +85,7 @@ abstract class AbstractReaderTest extends \PHPUnit_Framework_TestCase
     }
 
      /**
-     * @expectedException Doctrine\Common\Annotations\AnnotationException
+     * @expectedException \Doctrine\Common\Annotations\AnnotationException
      * @expectedExceptionMessage [Semantical Error] Annotation @AnnotationTargetPropertyMethod is not allowed to be declared on class Doctrine\Tests\Common\Annotations\Fixtures\ClassWithInvalidAnnotationTargetAtClass. You may only use this annotation on these code elements: METHOD, PROPERTY
      */
     public function testClassWithInvalidAnnotationTargetAtClassDocBlock()
@@ -111,7 +102,7 @@ abstract class AbstractReaderTest extends \PHPUnit_Framework_TestCase
     }
 
      /**
-     * @expectedException Doctrine\Common\Annotations\AnnotationException
+     * @expectedException \Doctrine\Common\Annotations\AnnotationException
      * @expectedExceptionMessage [Semantical Error] Annotation @AnnotationTargetClass is not allowed to be declared on property Doctrine\Tests\Common\Annotations\Fixtures\ClassWithInvalidAnnotationTargetAtProperty::$foo. You may only use this annotation on these code elements: CLASS
      */
     public function testClassWithInvalidAnnotationTargetAtPropertyDocBlock()
@@ -121,7 +112,7 @@ abstract class AbstractReaderTest extends \PHPUnit_Framework_TestCase
     }
 
      /**
-     * @expectedException Doctrine\Common\Annotations\AnnotationException
+     * @expectedException \Doctrine\Common\Annotations\AnnotationException
      * @expectedExceptionMessage [Semantical Error] Annotation @AnnotationTargetAnnotation is not allowed to be declared on property Doctrine\Tests\Common\Annotations\Fixtures\ClassWithInvalidAnnotationTargetAtProperty::$bar. You may only use this annotation on these code elements: ANNOTATION
      */
     public function testClassWithInvalidNestedAnnotationTargetAtPropertyDocBlock()
@@ -131,7 +122,7 @@ abstract class AbstractReaderTest extends \PHPUnit_Framework_TestCase
     }
 
      /**
-     * @expectedException Doctrine\Common\Annotations\AnnotationException
+     * @expectedException \Doctrine\Common\Annotations\AnnotationException
      * @expectedExceptionMessage [Semantical Error] Annotation @AnnotationTargetClass is not allowed to be declared on method Doctrine\Tests\Common\Annotations\Fixtures\ClassWithInvalidAnnotationTargetAtMethod::functionName(). You may only use this annotation on these code elements: CLASS
      */
     public function testClassWithInvalidAnnotationTargetAtMethodDocBlock()
@@ -141,7 +132,7 @@ abstract class AbstractReaderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Doctrine\Common\Annotations\AnnotationException
+     * @expectedException \Doctrine\Common\Annotations\AnnotationException
      * @expectedExceptionMessage Expected namespace separator or identifier, got ')' at position 24 in class @Doctrine\Tests\Common\Annotations\Fixtures\AnnotationWithTargetSyntaxError.
      */
     public function testClassWithAnnotationWithTargetSyntaxErrorAtClassDocBlock()
@@ -151,7 +142,7 @@ abstract class AbstractReaderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Doctrine\Common\Annotations\AnnotationException
+     * @expectedException \Doctrine\Common\Annotations\AnnotationException
      * @expectedExceptionMessage Expected namespace separator or identifier, got ')' at position 24 in class @Doctrine\Tests\Common\Annotations\Fixtures\AnnotationWithTargetSyntaxError.
      */
     public function testClassWithAnnotationWithTargetSyntaxErrorAtPropertyDocBlock()
@@ -161,7 +152,7 @@ abstract class AbstractReaderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Doctrine\Common\Annotations\AnnotationException
+     * @expectedException \Doctrine\Common\Annotations\AnnotationException
      * @expectedExceptionMessage Expected namespace separator or identifier, got ')' at position 24 in class @Doctrine\Tests\Common\Annotations\Fixtures\AnnotationWithTargetSyntaxError.
      */
     public function testClassWithAnnotationWithTargetSyntaxErrorAtMethodDocBlock()
@@ -171,7 +162,7 @@ abstract class AbstractReaderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Doctrine\Common\Annotations\AnnotationException
+     * @expectedException \Doctrine\Common\Annotations\AnnotationException
      * @expectedExceptionMessage [Type Error] Attribute "string" of @AnnotationWithVarType declared on property Doctrine\Tests\Common\Annotations\Fixtures\ClassWithAnnotationWithVarType::$invalidProperty expects a(n) string, but got integer.
      */
     public function testClassWithPropertyInvalidVarTypeError()
@@ -183,7 +174,7 @@ abstract class AbstractReaderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Doctrine\Common\Annotations\AnnotationException
+     * @expectedException \Doctrine\Common\Annotations\AnnotationException
      * @expectedExceptionMessage [Type Error] Attribute "annotation" of @AnnotationWithVarType declared on method Doctrine\Tests\Common\Annotations\Fixtures\ClassWithAnnotationWithVarType::invalidMethod() expects a(n) Doctrine\Tests\Common\Annotations\Fixtures\AnnotationTargetAll, but got an instance of Doctrine\Tests\Common\Annotations\Fixtures\AnnotationTargetAnnotation.
      */
     public function testClassWithMethodInvalidVarTypeError()
@@ -195,7 +186,7 @@ abstract class AbstractReaderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Doctrine\Common\Annotations\AnnotationException
+     * @expectedException \Doctrine\Common\Annotations\AnnotationException
      * @expectedExceptionMessage Expected namespace separator or identifier, got ')' at position 18 in class Doctrine\Tests\Common\Annotations\DummyClassSyntaxError.
      */
     public function testClassSyntaxErrorContext()
@@ -205,7 +196,7 @@ abstract class AbstractReaderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Doctrine\Common\Annotations\AnnotationException
+     * @expectedException \Doctrine\Common\Annotations\AnnotationException
      * @expectedExceptionMessage Expected namespace separator or identifier, got ')' at position 18 in method Doctrine\Tests\Common\Annotations\DummyClassMethodSyntaxError::foo().
      */
     public function testMethodSyntaxErrorContext()
@@ -215,7 +206,7 @@ abstract class AbstractReaderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Doctrine\Common\Annotations\AnnotationException
+     * @expectedException \Doctrine\Common\Annotations\AnnotationException
      * @expectedExceptionMessage Expected namespace separator or identifier, got ')' at position 18 in property Doctrine\Tests\Common\Annotations\DummyClassPropertySyntaxError::$foo.
      */
     public function testPropertySyntaxErrorContext()
@@ -268,7 +259,7 @@ abstract class AbstractReaderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Doctrine\Common\Annotations\AnnotationException
+     * @expectedException \Doctrine\Common\Annotations\AnnotationException
      * @expectedExceptionMessage The annotation "@NameFoo" in property Doctrine\Tests\Common\Annotations\TestAnnotationNotImportedClass::$field was never imported.
      */
     public function testImportDetectsNotImportedAnnotation()
@@ -278,7 +269,7 @@ abstract class AbstractReaderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Doctrine\Common\Annotations\AnnotationException
+     * @expectedException \Doctrine\Common\Annotations\AnnotationException
      * @expectedExceptionMessage The annotation "@Foo\Bar\Name" in property Doctrine\Tests\Common\Annotations\TestNonExistentAnnotationClass::$field was never imported.
      */
     public function testImportDetectsNonExistentAnnotation()
@@ -305,7 +296,7 @@ abstract class AbstractReaderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Doctrine\Common\Annotations\AnnotationException
+     * @expectedException \Doctrine\Common\Annotations\AnnotationException
      * @expectedExceptionMessage The class "Doctrine\Tests\Common\Annotations\Fixtures\NoAnnotation" is not annotated with @Annotation. Are you sure this class can be used as annotation? If so, then you need to add @Annotation to the _class_ doc comment of "Doctrine\Tests\Common\Annotations\Fixtures\NoAnnotation". If it is indeed no annotation, then you need to add @IgnoreAnnotation("NoAnnotation") to the _class_ doc comment of class Doctrine\Tests\Common\Annotations\Fixtures\InvalidAnnotationUsageClass.
      */
     public function testErrorWhenInvalidAnnotationIsUsed()
@@ -462,15 +453,15 @@ class DummyClass2 {
 }
 
 /** @Annotation */
-class DummyId extends \Doctrine\Common\Annotations\Annotation {}
+class DummyId extends Annotation {}
 /** @Annotation */
-class DummyColumn extends \Doctrine\Common\Annotations\Annotation {
+class DummyColumn extends Annotation {
     public $type;
 }
 /** @Annotation */
-class DummyGeneratedValue extends \Doctrine\Common\Annotations\Annotation {}
+class DummyGeneratedValue extends Annotation {}
 /** @Annotation */
-class DummyAnnotation extends \Doctrine\Common\Annotations\Annotation {
+class DummyAnnotation extends Annotation {
     public $dummyValue;
 }
 
@@ -478,17 +469,17 @@ class DummyAnnotation extends \Doctrine\Common\Annotations\Annotation {
  * @api
  * @Annotation
  */
-class DummyAnnotationWithIgnoredAnnotation extends \Doctrine\Common\Annotations\Annotation {
+class DummyAnnotationWithIgnoredAnnotation extends Annotation {
     public $dummyValue;
 }
 
 /** @Annotation */
-class DummyJoinColumn extends \Doctrine\Common\Annotations\Annotation {
+class DummyJoinColumn extends Annotation {
     public $name;
     public $referencedColumnName;
 }
 /** @Annotation */
-class DummyJoinTable extends \Doctrine\Common\Annotations\Annotation {
+class DummyJoinTable extends Annotation {
     public $name;
     public $joinColumns;
     public $inverseJoinColumns;

--- a/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
@@ -2,7 +2,6 @@
 
 namespace Doctrine\Tests\Common\Annotations;
 
-use Doctrine\Common\Annotations\Annotation\IgnorePhpDoc;
 use Doctrine\Common\Annotations\Annotation\IgnoreAnnotation;
 use Doctrine\Common\Annotations\DocParser;
 use Doctrine\Common\Annotations\AnnotationRegistry;
@@ -321,7 +320,7 @@ DOCBLOCK;
             $docComment = $class->getDocComment();
 
             $parser->setTarget(Target::TARGET_CLASS);
-            $parser->parse($class->getDocComment(),$context);
+            $parser->parse($docComment, $context);
 
             $this->fail();
         } catch (\Doctrine\Common\Annotations\AnnotationException $exc) {
@@ -337,7 +336,7 @@ DOCBLOCK;
             $context    = 'method ' . $class->getName() . '::' . $method->getName() . '()';
 
             $parser->setTarget(Target::TARGET_METHOD);
-            $parser->parse($docComment,$context);
+            $parser->parse($docComment, $context);
 
             $this->fail();
         } catch (\Doctrine\Common\Annotations\AnnotationException $exc) {
@@ -352,7 +351,7 @@ DOCBLOCK;
             $context    = 'property ' . $class->getName() . "::\$" . $property->getName();
 
             $parser->setTarget(Target::TARGET_PROPERTY);
-            $parser->parse($docComment,$context);
+            $parser->parse($docComment, $context);
 
             $this->fail();
         } catch (\Doctrine\Common\Annotations\AnnotationException $exc) {
@@ -666,7 +665,7 @@ DOCBLOCK;
     }
 
     /**
-     * @expectedException Doctrine\Common\Annotations\AnnotationException
+     * @expectedException \Doctrine\Common\Annotations\AnnotationException
      * @expectedExceptionMessage Attribute "value" of @Doctrine\Tests\Common\Annotations\Fixtures\AnnotationEnum declared on property SomeClassName::invalidProperty. accept only [ONE, TWO, THREE], but got FOUR.
      */
     public function testAnnotationEnumeratorException()
@@ -681,7 +680,7 @@ DOCBLOCK;
     }
 
     /**
-     * @expectedException Doctrine\Common\Annotations\AnnotationException
+     * @expectedException \Doctrine\Common\Annotations\AnnotationException
      * @expectedExceptionMessage Attribute "value" of @Doctrine\Tests\Common\Annotations\Fixtures\AnnotationEnumLiteral declared on property SomeClassName::invalidProperty. accept only [AnnotationEnumLiteral::ONE, AnnotationEnumLiteral::TWO, AnnotationEnumLiteral::THREE], but got 4.
      */
     public function testAnnotationEnumeratorLiteralException()
@@ -810,7 +809,7 @@ DOCBLOCK;
     }
 
     /**
-     * @expectedException Doctrine\Common\Annotations\AnnotationException
+     * @expectedException \Doctrine\Common\Annotations\AnnotationException
      * @expectedExceptionMessage The annotation @SomeAnnotationClassNameWithoutConstructorAndProperties declared on  does not accept any values, but got {"value":"Foo"}.
      */
     public function testWithoutConstructorWhenIsNotDefaultValue()
@@ -828,7 +827,7 @@ DOCBLOCK;
     }
 
     /**
-     * @expectedException Doctrine\Common\Annotations\AnnotationException
+     * @expectedException \Doctrine\Common\Annotations\AnnotationException
      * @expectedExceptionMessage The annotation @SomeAnnotationClassNameWithoutConstructorAndProperties declared on  does not accept any values, but got {"value":"Foo"}.
      */
     public function testWithoutConstructorWhenHasNoProperties()
@@ -845,7 +844,7 @@ DOCBLOCK;
     }
 
     /**
-     * @expectedException Doctrine\Common\Annotations\AnnotationException
+     * @expectedException \Doctrine\Common\Annotations\AnnotationException
      * @expectedExceptionMessage Expected namespace separator or identifier, got ')' at position 24 in class @Doctrine\Tests\Common\Annotations\Fixtures\AnnotationWithTargetSyntaxError.
      */
     public function testAnnotationTargetSyntaxError()
@@ -944,7 +943,7 @@ DOCBLOCK;
     }
 
     /**
-     * @expectedException Doctrine\Common\Annotations\AnnotationException
+     * @expectedException \Doctrine\Common\Annotations\AnnotationException
      * @expectedExceptionMessage Expected PlainValue, got ''' at position 10.
      */
     public function testAnnotationDontAcceptSingleQuotes()
@@ -966,12 +965,12 @@ DOCBLOCK;
 
     /**
      * @group DCOM-41
-     * @expectedException Doctrine\Common\Annotations\AnnotationException
+     * @expectedException \Doctrine\Common\Annotations\AnnotationException
      */
     public function testAnnotationThrowsExceptionWhenAtSignIsNotFollowedByIdentifierInNestedAnnotation()
     {
         $parser = new DocParser();
-        $result = $parser->parse("@Doctrine\Tests\Common\Annotations\Name(@')");
+        $parser->parse("@Doctrine\Tests\Common\Annotations\Name(@')");
     }
 
     /**
@@ -1008,7 +1007,7 @@ DOCBLOCK;
 
     /**
      * @group DDC-78
-     * @expectedException Doctrine\Common\Annotations\AnnotationException
+     * @expectedException \Doctrine\Common\Annotations\AnnotationException
      * @expectedExceptionMessage Expected PlainValue, got ''' at position 10 in class \Doctrine\Tests\Common\Annotations\Name
      */
     public function testSyntaxErrorWithContextDescription()
@@ -1036,8 +1035,8 @@ DOCBLOCK;
 
         try {
             $parser = $this->createTestParser();
-            $result = $parser->parse($docblock);
-        } catch (Exception $e) {
+            $parser->parse($docblock);
+        } catch (\Exception $e) {
             $this->fail($e->getMessage());
         }
     }
@@ -1057,8 +1056,8 @@ DOCBLOCK;
 
         try {
             $parser = $this->createTestParser();
-            $result = $parser->parse($docblock);
-        } catch (Exception $e) {
+            $parser->parse($docblock);
+        } catch (\Exception $e) {
             $this->fail($e->getMessage());
         }
     }
@@ -1135,7 +1134,7 @@ DOCBLOCK;
     }
 
      /**
-     * @expectedException Doctrine\Common\Annotations\AnnotationException
+     * @expectedException \Doctrine\Common\Annotations\AnnotationException
      * @expectedExceptionMessage [Creation Error] The annotation @SomeAnnotationClassNameWithoutConstructor declared on some class does not have a property named "invalidaProperty". Available properties: data, name
      */
     public function testSetValuesExeption()
@@ -1150,7 +1149,7 @@ DOCBLOCK;
     }
 
     /**
-     * @expectedException Doctrine\Common\Annotations\AnnotationException
+     * @expectedException \Doctrine\Common\Annotations\AnnotationException
      * @expectedExceptionMessage [Syntax Error] Expected Doctrine\Common\Annotations\DocLexer::T_IDENTIFIER or Doctrine\Common\Annotations\DocLexer::T_TRUE or Doctrine\Common\Annotations\DocLexer::T_FALSE or Doctrine\Common\Annotations\DocLexer::T_NULL, got '3.42' at position 5.
      */
     public function testInvalidIdentifierInAnnotation()
@@ -1190,7 +1189,7 @@ DOCBLOCK;
     }
 
     /**
-     * @expectedException Doctrine\Common\Annotations\AnnotationException
+     * @expectedException \Doctrine\Common\Annotations\AnnotationException
      * @expectedExceptionMessage [Semantical Error] Couldn't find constant foo.
      */
     public function testInvalidContantName()

--- a/tests/Doctrine/Tests/Common/Annotations/FileCacheReaderTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/FileCacheReaderTest.php
@@ -33,7 +33,7 @@ class FileCacheReaderTest extends AbstractReaderTest
 
         $this->assertFalse(is_dir($this->cacheDir));
 
-        $cache = new FileCacheReader(new AnnotationReader(), $this->cacheDir);
+        new FileCacheReader(new AnnotationReader(), $this->cacheDir);
 
         $this->assertTrue(is_dir($this->cacheDir));
     }

--- a/tests/Doctrine/Tests/Common/Annotations/SimpleAnnotationReaderTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/SimpleAnnotationReaderTest.php
@@ -61,7 +61,7 @@ class SimpleAnnotationReaderTest extends AbstractReaderTest
     }
 
     /**
-     * @expectedException Doctrine\Common\Annotations\AnnotationException
+     * @expectedException \Doctrine\Common\Annotations\AnnotationException
      */
     public function testInvalidAnnotationUsageButIgnoredClass()
     {

--- a/tests/Doctrine/Tests/Common/Annotations/Ticket/DCOM55Test.php
+++ b/tests/Doctrine/Tests/Common/Annotations/Ticket/DCOM55Test.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Tests\Common\Annotations\Ticket;
 
 use Doctrine\Tests\Common\Annotations\Fixtures\Controller;
+use Doctrine\Common\Annotations\AnnotationReader;
 
 /**
  * @group
@@ -10,20 +11,20 @@ use Doctrine\Tests\Common\Annotations\Fixtures\Controller;
 class DCOM55Test extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @expectedException Doctrine\Common\Annotations\AnnotationException
+     * @expectedException \Doctrine\Common\Annotations\AnnotationException
      * @expectedExceptionMessage [Semantical Error] The class "Doctrine\Tests\Common\Annotations\Fixtures\Controller" is not annotated with @Annotation. Are you sure this class can be used as annotation? If so, then you need to add @Annotation to the _class_ doc comment of "Doctrine\Tests\Common\Annotations\Fixtures\Controller". If it is indeed no annotation, then you need to add @IgnoreAnnotation("Controller") to the _class_ doc comment of class Doctrine\Tests\Common\Annotations\Ticket\Dummy.
      */
     public function testIssue()
     {
         $class = new \ReflectionClass(__NAMESPACE__ . '\\Dummy');
-        $reader = new \Doctrine\Common\Annotations\AnnotationReader();
+        $reader = new AnnotationReader();
         $reader->getClassAnnotations($class);
     }
 
     public function testAnnotation()
     {
         $class = new \ReflectionClass(__NAMESPACE__ . '\\DCOM55Consumer');
-        $reader = new \Doctrine\Common\Annotations\AnnotationReader();
+        $reader = new AnnotationReader();
         $annots = $reader->getClassAnnotations($class);
 
         $this->assertEquals(1, count($annots));
@@ -33,7 +34,7 @@ class DCOM55Test extends \PHPUnit_Framework_TestCase
     public function testParseAnnotationDocblocks()
     {
         $class = new \ReflectionClass(__NAMESPACE__ . '\\DCOM55Annotation');
-        $reader = new \Doctrine\Common\Annotations\AnnotationReader();
+        $reader = new AnnotationReader();
         $annots = $reader->getClassAnnotations($class);
 
         $this->assertEquals(0, count($annots));

--- a/tests/Doctrine/Tests/Common/Annotations/Ticket/DCOM58Test.php
+++ b/tests/Doctrine/Tests/Common/Annotations/Ticket/DCOM58Test.php
@@ -1,6 +1,10 @@
 <?php
 namespace Doctrine\Tests\Common\Annotations\Ticket;
 
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\Annotations\DocParser;
+use Doctrine\Common\Annotations\SimpleAnnotationReader;
+
 //Some class named Entity in the global namespace
 include __DIR__ .'/DCOM58Entity.php';
 
@@ -11,7 +15,7 @@ class DCOM58Test extends \PHPUnit_Framework_TestCase
 {
     public function testIssue()
     {
-        $reader     = new \Doctrine\Common\Annotations\AnnotationReader();
+        $reader     = new AnnotationReader();
         $result     = $reader->getClassAnnotations(new \ReflectionClass(__NAMESPACE__."\MappedClass"));
 
         foreach ($result as $annot) {
@@ -24,7 +28,7 @@ class DCOM58Test extends \PHPUnit_Framework_TestCase
     public function testIssueGlobalNamespace()
     {
         $docblock   = "@Entity";
-        $parser     = new \Doctrine\Common\Annotations\DocParser();
+        $parser     = new DocParser();
         $parser->setImports(array(
             "__NAMESPACE__" =>"Doctrine\Tests\Common\Annotations\Ticket\Doctrine\ORM\Mapping"
         ));
@@ -38,7 +42,7 @@ class DCOM58Test extends \PHPUnit_Framework_TestCase
     public function testIssueNamespaces()
     {
         $docblock   = "@Entity";
-        $parser     = new \Doctrine\Common\Annotations\DocParser();
+        $parser     = new DocParser();
         $parser->addNamespace("Doctrine\Tests\Common\Annotations\Ticket\Doctrine\ORM");
 
         $annots     = $parser->parse($docblock);
@@ -50,7 +54,7 @@ class DCOM58Test extends \PHPUnit_Framework_TestCase
     public function testIssueMultipleNamespaces()
     {
         $docblock   = "@Entity";
-        $parser     = new \Doctrine\Common\Annotations\DocParser();
+        $parser     = new DocParser();
         $parser->addNamespace("Doctrine\Tests\Common\Annotations\Ticket\Doctrine\ORM\Mapping");
         $parser->addNamespace("Doctrine\Tests\Common\Annotations\Ticket\Doctrine\ORM");
 
@@ -63,7 +67,7 @@ class DCOM58Test extends \PHPUnit_Framework_TestCase
     public function testIssueWithNamespacesOrImports()
     {
         $docblock   = "@Entity";
-        $parser     = new \Doctrine\Common\Annotations\DocParser();
+        $parser     = new DocParser();
         $annots     = $parser->parse($docblock);
 
         $this->assertEquals(1, count($annots));
@@ -74,7 +78,7 @@ class DCOM58Test extends \PHPUnit_Framework_TestCase
 
     public function testIssueSimpleAnnotationReader()
     {
-        $reader     = new \Doctrine\Common\Annotations\SimpleAnnotationReader();
+        $reader     = new SimpleAnnotationReader();
         $reader->addNamespace('Doctrine\Tests\Common\Annotations\Ticket\Doctrine\ORM\Mapping');
         $annots     = $reader->getClassAnnotations(new \ReflectionClass(__NAMESPACE__."\MappedClass"));
 


### PR DESCRIPTION
I wanted to dive a bit in the code, but the tests where almost unreadable. I fixed warnings (in PhpStorm) about unused imports, non existent classes, unused variables in tests files…

I also imported some classes (`use ...`) at some places when appropriate.

All tests are good.

FYI I didn't change a thing in non-tests files except one wrong `@return` phpdoc.
