### PR TITLE
Set `1.1-dev` as dev-master alias instead of `1.0.*-dev`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0.x-dev"
+            "dev-master": "1.1-dev"
         }
     }
 }


### PR DESCRIPTION
Last unstable version is 1.0.\* while last stable version is 1.1.2
