### PR TITLE
setIgnoreNotImportedAnnotations(true) didn’t work for existing classes.

### DIFF
--- a/lib/Doctrine/Common/Annotations/DocParser.php
+++ b/lib/Doctrine/Common/Annotations/DocParser.php
@@ -675,7 +675,7 @@ final class DocParser
 
         // verify that the class is really meant to be an annotation and not just any ordinary class
         if (self::$annotationMetadata[$name]['is_annotation'] === false) {
-            if (isset($this->ignoredAnnotationNames[$originalName])) {
+            if ($this->ignoreNotImportedAnnotations || isset($this->ignoredAnnotationNames[$originalName])) {
                 return false;
             }
 

--- a/tests/Doctrine/Tests/Common/Annotations/AbstractReaderTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/AbstractReaderTest.php
@@ -366,8 +366,11 @@ abstract class AbstractReaderTest extends \PHPUnit_Framework_TestCase
         $reader = $this->getReader();
         $ref = new \ReflectionClass('Doctrine\Tests\Common\Annotations\Fixtures\InvalidAnnotationUsageButIgnoredClass');
         $annots = $reader->getClassAnnotations($ref);
-
-        $this->assertEquals(2, count($annots));
+        if ($annots[0] instanceof IgnoreAnnotation) {
+            $this->assertEquals(2, count($annots));
+        } else { // SimpleAnnotationReader doens't include the IgnoreAnnotation in the results.
+            $this->assertEquals(1, count($annots));
+        }
     }
 
     /**

--- a/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
@@ -956,6 +956,15 @@ DOCBLOCK;
         $this->assertEquals(0, count($result));
     }
 
+    public function testNotAnAnnotationClassIsIgnoredWithoutWarning()
+    {
+        $parser = new DocParser();
+        $parser->setIgnoreNotImportedAnnotations(true);
+        $result = $parser->parse('@PHPUnit_Framework_TestCase');
+
+        $this->assertEquals(0, count($result));
+    }
+
     /**
      * @expectedException \Doctrine\Common\Annotations\AnnotationException
      * @expectedExceptionMessage Expected PlainValue, got ''' at position 10.

--- a/tests/Doctrine/Tests/Common/Annotations/SimpleAnnotationReaderTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/SimpleAnnotationReaderTest.php
@@ -61,7 +61,17 @@ class SimpleAnnotationReaderTest extends AbstractReaderTest
     }
 
     /**
-     * @expectedException \Doctrine\Common\Annotations\AnnotationException
+     * Contrary to the behavior of the default annotation reader, we do just ignore
+     * these in the simple annotation reader (so, no expected exception here).
+     */
+    public function testErrorWhenInvalidAnnotationIsUsed()
+    {
+        parent::testErrorWhenInvalidAnnotationIsUsed();
+    }
+
+    /**
+     * Contrary to the behavior of the default annotation reader, we do just ignore
+     * these in the simple annotation reader (so, no expected exception here).
      */
     public function testInvalidAnnotationUsageButIgnoredClass()
     {


### PR DESCRIPTION
Because FuelPHP has a Package class, which isn’t an @Annotation the following error occurs:

> [Semantical Error] The class "package" is not annotated with @Annotation. Are you sure this class can be used as annotation? If so, then you need to add @Annotation to the _class_ doc comment of "package". If it is indeed no annotation, then you need to add @IgnoreAnnotation("package") to the _class_ doc comment of ...

Using @IgnoreAnnotation("package") won’t help because this issue also affects the AnnotationReader->preParser, so this error also occurs when trying to extract the @IgnoreAnnotations
