### PR TITLE
Deprecate AnnotationRegistry in favor of class_exists()

### DIFF
--- a/lib/Doctrine/Common/Annotations/AnnotationReader.php
+++ b/lib/Doctrine/Common/Annotations/AnnotationReader.php
@@ -160,7 +160,7 @@ class AnnotationReader implements Reader
             throw AnnotationException::optimizerPlusSaveComments();
         }
 
-        AnnotationRegistry::registerFile(__DIR__ . '/Annotation/IgnoreAnnotation.php');
+        require_once __DIR__ . '/Annotation/IgnoreAnnotation.php';
 
         $this->parser    = new DocParser;
         $this->preParser = new DocParser;

--- a/lib/Doctrine/Common/Annotations/AnnotationRegistry.php
+++ b/lib/Doctrine/Common/Annotations/AnnotationRegistry.php
@@ -21,6 +21,8 @@ namespace Doctrine\Common\Annotations;
 
 /**
  * AnnotationRegistry
+ *
+ * @deprecated Rely on spl_register_autoloader() autoloaders instead
  */
 final class AnnotationRegistry
 {

--- a/lib/Doctrine/Common/Annotations/DocParser.php
+++ b/lib/Doctrine/Common/Annotations/DocParser.php
@@ -401,13 +401,8 @@ final class DocParser
             return $this->classExists[$fqcn];
         }
 
-        // first check if the class already exists, maybe loaded through another AnnotationReader
-        if (class_exists($fqcn, false)) {
-            return $this->classExists[$fqcn] = true;
-        }
-
         // final check, does this class exist?
-        return $this->classExists[$fqcn] = AnnotationRegistry::loadAnnotationClass($fqcn);
+        return $this->classExists[$fqcn] = class_exists($fqcn) || AnnotationRegistry::loadAnnotationClass($fqcn);
     }
 
     /**
@@ -429,10 +424,10 @@ final class DocParser
                 'attributes'    => 'Doctrine\Common\Annotations\Annotation\Attributes'
             ));
 
-            AnnotationRegistry::registerFile(__DIR__ . '/Annotation/Enum.php');
-            AnnotationRegistry::registerFile(__DIR__ . '/Annotation/Target.php');
-            AnnotationRegistry::registerFile(__DIR__ . '/Annotation/Attribute.php');
-            AnnotationRegistry::registerFile(__DIR__ . '/Annotation/Attributes.php');
+            require_once __DIR__ . '/Annotation/Enum.php';
+            require_once __DIR__ . '/Annotation/Target.php';
+            require_once __DIR__ . '/Annotation/Attribute.php';
+            require_once __DIR__ . '/Annotation/Attributes.php';
         }
 
         $class      = new \ReflectionClass($name);
@@ -474,7 +469,7 @@ final class DocParser
                 // collect all public properties
                 foreach ($class->getProperties(\ReflectionProperty::IS_PUBLIC) as $property) {
                     $metadata['properties'][$property->name] = $property->name;
-                    
+
                     if (false === ($propertyComment = $property->getDocComment())) {
                         continue;
                     }


### PR DESCRIPTION
See also: https://github.com/doctrine/common/issues/321

Actually it looks like there is no benefit in using a separate autoloading mechanism, which itself only makes (manual) use of "real" autoloaders. Instead `class_exists()` serves the same purpose and prevents one from the need to [manually add an autoloader](https://github.com/symfony/symfony-standard/blob/master/app/autoload.php#L11) for every loader, that should load annotations.

This is especially interesting now, that composer took over most of the autoloading related issues in many projects.

I don't know, which deprecation-rules apply here, so I just added the tag and kept the class as it is, but remove the use wherever useful.
