### PR TITLE
Added phpunit as a dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
         "doctrine/lexer": "1.*"
     },
     "require-dev": {
-        "doctrine/cache": "1.*"
+        "doctrine/cache": "1.*",
+        "phpunit/phpunit": "4.*"
     },
     "autoload": {
         "psr-0": { "Doctrine\\Common\\Annotations\\": "lib/" }


### PR DESCRIPTION
It would be nice to add phpunit as a dev dependency in composer.json, as already present in DBAL and ORM.

Otherwise it forces you to have phpunit installed globally to run the tests.
