### PR TITLE
Ignored @startuml and @stopuml annotations

### DIFF
--- a/lib/Doctrine/Common/Annotations/AnnotationReader.php
+++ b/lib/Doctrine/Common/Annotations/AnnotationReader.php
@@ -98,6 +98,8 @@ class AnnotationReader implements Reader
         'noinspection' => true,
         // PEAR
         'package_version' => true,
+        // PlantUML
+        'startuml' => true, 'enduml' => true,
     );
 
     /**


### PR DESCRIPTION
PlantUML (http://plantuml.sourceforge.net/), a tool for text based UML diagrams that can be added in-line in the code uses
@startuml and @enduml annotations. It would be great to be able to put those inside a docblock.
