### PR TITLE
Warn if load_comments is not enabled.

### DIFF
--- a/lib/Doctrine/Common/Annotations/AnnotationException.php
+++ b/lib/Doctrine/Common/Annotations/AnnotationException.php
@@ -184,4 +184,14 @@ class AnnotationException extends \Exception
             "You have to enable opcache.save_comments=1 or zend_optimizerplus.save_comments=1."
         );
     }
+
+    /**
+     * @return AnnotationException
+     */
+    public static function optimizerPlusLoadComments()
+    {
+        return new self(
+            "You have to enable opcache.load_comments=1 or zend_optimizerplus.load_comments=1."
+        );
+    }
 }

--- a/lib/Doctrine/Common/Annotations/AnnotationReader.php
+++ b/lib/Doctrine/Common/Annotations/AnnotationReader.php
@@ -162,6 +162,15 @@ class AnnotationReader implements Reader
             throw AnnotationException::optimizerPlusSaveComments();
         }
 
+
+        if (extension_loaded('Zend Optimizer+') && (ini_get('zend_optimizerplus.load_comments') === "0" || ini_get('opcache.load_comments') === "0")) {
+            throw AnnotationException::optimizerPlusLoadComments();
+        }
+
+        if (extension_loaded('Zend OPcache') && ini_get('opcache.load_comments') == 0) {
+            throw AnnotationException::optimizerPlusLoadComments();
+        }
+
         AnnotationRegistry::registerFile(__DIR__ . '/Annotation/IgnoreAnnotation.php');
 
         $this->parser    = new DocParser;


### PR DESCRIPTION
It is possible to have save_comments=1 but load_comments=0, in which case you get no warning but the Annotations Reader will not work.

Since there is an Exception about save_comments, it should also throw an error about load_comments to provide consistency. 
