### PR TITLE
DocParser can now ignore whole namespaces

### DIFF
--- a/lib/Doctrine/Common/Annotations/AnnotationReader.php
+++ b/lib/Doctrine/Common/Annotations/AnnotationReader.php
@@ -103,6 +103,15 @@ class AnnotationReader implements Reader
     );
 
     /**
+     * A list with annotations that are not causing exceptions when not resolved to an annotation class.
+     *
+     * The names are case sensitive.
+     *
+     * @var array
+     */
+    private static $globalIgnoredNamespaces = array();
+
+    /**
      * Add a new annotation to the globally ignored annotation names with regard to exception handling.
      *
      * @param string $name
@@ -110,6 +119,16 @@ class AnnotationReader implements Reader
     static public function addGlobalIgnoredName($name)
     {
         self::$globalIgnoredNames[$name] = true;
+    }
+
+    /**
+     * Add a new annotation to the globally ignored annotation namespaces with regard to exception handling.
+     *
+     * @param string $namespace
+     */
+    static public function addGlobalIgnoredNamespace($namespace)
+    {
+        self::$globalIgnoredNamespaces[$namespace] = true;
     }
 
     /**
@@ -190,6 +209,7 @@ class AnnotationReader implements Reader
         $this->parser->setTarget(Target::TARGET_CLASS);
         $this->parser->setImports($this->getClassImports($class));
         $this->parser->setIgnoredAnnotationNames($this->getIgnoredAnnotationNames($class));
+        $this->parser->setIgnoredAnnotationNamespaces(self::$globalIgnoredNamespaces);
 
         return $this->parser->parse($class->getDocComment(), 'class ' . $class->getName());
     }
@@ -221,6 +241,7 @@ class AnnotationReader implements Reader
         $this->parser->setTarget(Target::TARGET_PROPERTY);
         $this->parser->setImports($this->getPropertyImports($property));
         $this->parser->setIgnoredAnnotationNames($this->getIgnoredAnnotationNames($class));
+        $this->parser->setIgnoredAnnotationNamespaces(self::$globalIgnoredNamespaces);
 
         return $this->parser->parse($property->getDocComment(), $context);
     }
@@ -252,6 +273,7 @@ class AnnotationReader implements Reader
         $this->parser->setTarget(Target::TARGET_METHOD);
         $this->parser->setImports($this->getMethodImports($method));
         $this->parser->setIgnoredAnnotationNames($this->getIgnoredAnnotationNames($class));
+        $this->parser->setIgnoredAnnotationNamespaces(self::$globalIgnoredNamespaces);
 
         return $this->parser->parse($method->getDocComment(), $context);
     }

--- a/lib/Doctrine/Common/Annotations/DocParser.php
+++ b/lib/Doctrine/Common/Annotations/DocParser.php
@@ -700,6 +700,14 @@ final class DocParser
                     return false;
                 }
 
+                foreach (array_keys($this->ignoredAnnotationNames) as $annotationName) {
+                    $annotationName = rtrim($annotationName, '\\') . '\\';
+
+                    if (0 === stripos($name, $annotationName) || 0 === stripos($name . '\\', $annotationName)) {
+                        return false;
+                    }
+                }
+
                 throw AnnotationException::semanticalError(sprintf('The annotation "@%s" in %s was never imported. Did you maybe forget to add a "use" statement for this annotation?', $name, $this->context));
             }
         }

--- a/lib/Doctrine/Common/Annotations/DocParser.php
+++ b/lib/Doctrine/Common/Annotations/DocParser.php
@@ -120,6 +120,14 @@ final class DocParser
     private $ignoredAnnotationNames = array();
 
     /**
+     * A list with annotations in namespaced format
+     * that are not causing exceptions when not resolved to an annotation class.
+     *
+     * @var array
+     */
+    private $ignoredAnnotationNamespaces = array();
+
+    /**
      * @var string
      */
     private $context = '';
@@ -249,6 +257,18 @@ final class DocParser
     public function setIgnoredAnnotationNames(array $names)
     {
         $this->ignoredAnnotationNames = $names;
+    }
+
+    /**
+     * Sets the annotation namespaces that are ignored during the parsing process.
+     *
+     * @param array $ignoredAnnotationNamespaces
+     *
+     * @return void
+     */
+    public function setIgnoredAnnotationNamespaces($ignoredAnnotationNamespaces)
+    {
+        $this->ignoredAnnotationNamespaces = $ignoredAnnotationNamespaces;
     }
 
     /**
@@ -700,10 +720,10 @@ final class DocParser
                     return false;
                 }
 
-                foreach (array_keys($this->ignoredAnnotationNames) as $annotationName) {
-                    $annotationName = rtrim($annotationName, '\\') . '\\';
+                foreach (array_keys($this->ignoredAnnotationNamespaces) as $ignoredAnnotationNamespace) {
+                    $ignoredAnnotationNamespace = rtrim($ignoredAnnotationNamespace, '\\') . '\\';
 
-                    if (0 === stripos($name, $annotationName) || 0 === stripos($name . '\\', $annotationName)) {
+                    if (0 === stripos($name, $ignoredAnnotationNamespace) || 0 === stripos($name . '\\', $ignoredAnnotationNamespace)) {
                         return false;
                     }
                 }

--- a/tests/Doctrine/Tests/Common/Annotations/AnnotationReaderTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/AnnotationReaderTest.php
@@ -56,4 +56,58 @@ class AnnotationReaderTest extends AbstractReaderTest
         $this->assertInstanceOf('Doctrine\Tests\Common\Annotations\Fixtures\Annotation\Autoload', $annotations[0]);
     }
 
+    public function testClassAnnotationIsIgnored()
+    {
+        $reader = $this->getReader();
+        $ref = new \ReflectionClass('Doctrine\Tests\Common\Annotations\TestInvalidClassAnnotationClass');
+
+        $reader::addGlobalIgnoredNamespace('SomeClassAnnotationNamespace');
+
+        $annotations = $reader->getClassAnnotations($ref);
+
+        $this->assertEquals(0, count($annotations));
+    }
+
+    public function testMethodAnnotationIsIgnored()
+    {
+        $reader = $this->getReader();
+        $ref = new \ReflectionClass('Doctrine\Tests\Common\Annotations\TestInvalidMethodAnnotationClass');
+
+        $reader::addGlobalIgnoredNamespace('SomeMethodAnnotationNamespace');
+
+        $annotations = $reader->getMethodAnnotations($ref->getMethod('test'));
+
+        $this->assertEquals(0, count($annotations));
+    }
+
+    public function testPropertyAnnotationIsIgnored()
+    {
+        $reader = $this->getReader();
+        $ref = new \ReflectionClass('Doctrine\Tests\Common\Annotations\TestInvalidPropertyAnnotationClass');
+
+        $reader::addGlobalIgnoredNamespace('SomePropertyAnnotationNamespace');
+
+        $annotations = $reader->getPropertyAnnotations($ref->getProperty('field'));
+
+        $this->assertEquals(0, count($annotations));
+    }
+}
+
+/**
+ * @SomeClassAnnotationNamespace\Subnamespace\Name
+ */
+class TestInvalidClassAnnotationClass {}
+
+class TestInvalidMethodAnnotationClass {
+    /**
+     * @SomeMethodAnnotationNamespace\Subnamespace\Name
+     */
+    public function test() {}
+}
+
+class TestInvalidPropertyAnnotationClass {
+    /**
+     * @SomePropertyAnnotationNamespace\Subnamespace\Name
+     */
+    private $field;
 }

--- a/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
@@ -1006,7 +1006,7 @@ DOCBLOCK;
     public function testIgnoreWholeNamespaces($ignoreAnnotationName, $input)
     {
         $parser = new DocParser();
-        $parser->setIgnoredAnnotationNames(array($ignoreAnnotationName => true));
+        $parser->setIgnoredAnnotationNamespaces(array($ignoreAnnotationName => true));
         $result = $parser->parse($input);
 
         $this->assertEquals(0, count($result));

--- a/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
@@ -994,6 +994,48 @@ DOCBLOCK;
     }
 
     /**
+     * Tests if it's possible to ignore whole namespaces
+     *
+     * @param $ignoreAnnotationName annotation/namespace to ignore
+     * @param $input annotation/namespace from the docblock
+     *
+     * @return void
+     *
+     * @dataProvider provideTestIgnoreWholeNamespaces
+     */
+    public function testIgnoreWholeNamespaces($ignoreAnnotationName, $input)
+    {
+        $parser = new DocParser();
+        $parser->setIgnoredAnnotationNames(array($ignoreAnnotationName => true));
+        $result = $parser->parse($input);
+
+        $this->assertEquals(0, count($result));
+    }
+
+    public function provideTestIgnoreWholeNamespaces()
+    {
+        return array(
+            array('Namespace', '@Namespace'),
+            array('Namespace\\', '@Namespace'),
+
+            array('Namespace', '@Namespace\Subnamespace'),
+            array('Namespace\\', '@Namespace\Subnamespace'),
+
+            array('Namespace', '@Namespace\Subnamespace\SubSubNamespace'),
+            array('Namespace\\', '@Namespace\Subnamespace\SubSubNamespace'),
+
+            array('Namespace\Subnamespace', '@Namespace\Subnamespace'),
+            array('Namespace\Subnamespace\\', '@Namespace\Subnamespace'),
+
+            array('Namespace\Subnamespace', '@Namespace\Subnamespace\SubSubNamespace'),
+            array('Namespace\Subnamespace\\', '@Namespace\Subnamespace\SubSubNamespace'),
+
+            array('Namespace\Subnamespace\SubSubNamespace', '@Namespace\Subnamespace\SubSubNamespace'),
+            array('Namespace\Subnamespace\SubSubNamespace\\', '@Namespace\Subnamespace\SubSubNamespace'),
+        );
+    }
+
+    /**
      * @group DCOM-168
      */
     public function testNotAnAnnotationClassIsIgnoredWithoutWarning()


### PR DESCRIPTION
We would like to ignore whole namespaces in the annotation-reader.

We use swagger-php to document our REST-API in our source code. However, zircote/swagger-php is a dev dependency and therefore not deployed to the production environment. As we use doctrine, the Application crashes because the AnnotationReader (used by doctrine-orm) throws an Exception because it can't resolve the `@SWG\*` annotations.

To fix this, we have to register every Swagger-Annotation with AnnotationReader::addGlobalIgnoredName();

This leads to this code (list of swagger annotations: http://zircote.com/swagger-php/annotations.html#annotation-hierarchy):

```php
\Doctrine\Common\Annotations\AnnotationReader::addGlobalIgnoredName('SWG\Resource');
\Doctrine\Common\Annotations\AnnotationReader::addGlobalIgnoredName('SWG\Api');
\Doctrine\Common\Annotations\AnnotationReader::addGlobalIgnoredName('SWG\Operation');
\Doctrine\Common\Annotations\AnnotationReader::addGlobalIgnoredName('SWG\Parameter');
\Doctrine\Common\Annotations\AnnotationReader::addGlobalIgnoredName('SWG\ResponseMessage');
\Doctrine\Common\Annotations\AnnotationReader::addGlobalIgnoredName('SWG\Model');
\Doctrine\Common\Annotations\AnnotationReader::addGlobalIgnoredName('SWG\Property');
\Doctrine\Common\Annotations\AnnotationReader::addGlobalIgnoredName('SWG\Items');
\Doctrine\Common\Annotations\AnnotationReader::addGlobalIgnoredName('SWG\Authorization');
\Doctrine\Common\Annotations\AnnotationReader::addGlobalIgnoredName('SWG\Scope');
\Doctrine\Common\Annotations\AnnotationReader::addGlobalIgnoredName('SWG\Info');
```

With this PR, we could use:
```php
\Doctrine\Common\Annotations\AnnotationReader::addGlobalIgnoredNamespace('SWG');
```
And won't have to update the global ignores if a new swagger annotation is introduced (with an update).