### PR TITLE
Use FilesystemCache from Doctrine\Common\Cache

### DIFF
--- a/tests/Doctrine/Tests/Common/Annotations/FileCacheReaderTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/FileCacheReaderTest.php
@@ -4,6 +4,9 @@ namespace Doctrine\Tests\Common\Annotations;
 
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Annotations\FileCacheReader;
+use FilesystemIterator;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
 
 class FileCacheReaderTest extends AbstractReaderTest
 {
@@ -18,8 +21,12 @@ class FileCacheReaderTest extends AbstractReaderTest
 
     public function tearDown()
     {
-        foreach (glob($this->cacheDir.'/*.php') AS $file) {
-            unlink($file);
+        $files = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($this->cacheDir, FilesystemIterator::SKIP_DOTS), RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach($files as $path) {
+            $path->isDir() && !$path->isLink() ? rmdir($path->getPathname()) : unlink($path->getPathname());
         }
         rmdir($this->cacheDir);
     }


### PR DESCRIPTION
Directly using a FilesystemCache from Doctrine\Common\Cache.

I added the filemtime to the cacheKey. This will cause mor stats on the files, but hopefully phps statcache will solve this.

I think these are the minimal changes to use Doctrine\Common\Cache. I think it would be better to pass a Cache implementation to the constructor but this would also cause a BC break, which I tried not to do.
