### PR TITLE
FileCacheReader::saveCacheFile::unlink fix

### DIFF
--- a/lib/Doctrine/Common/Annotations/FileCacheReader.php
+++ b/lib/Doctrine/Common/Annotations/FileCacheReader.php
@@ -207,11 +207,11 @@ class FileCacheReader implements Reader
         }
 
         if (false === rename($tempfile, $path)) {
+            @unlink($tempfile);
             throw new \RuntimeException(sprintf('Unable to rename %s to %s', $tempfile, $path));
         }
 
         @chmod($path, 0666 & ~umask());
-        @unlink($tempfile);
     }
 
     /**


### PR DESCRIPTION
~~`$tempfile` is not correct because there's a `rename` func. call on `$tempfile` (to `$path`) before the `unlink` func. call~~
