### PR TITLE
Add annotations of PSR-5 (PHPDoc standard)

### DIFF
--- a/lib/Doctrine/Common/Annotations/AnnotationReader.php
+++ b/lib/Doctrine/Common/Annotations/AnnotationReader.php
@@ -100,6 +100,8 @@ class AnnotationReader implements Reader
         'package_version' => true,
         // PlantUML
         'startuml' => true, 'enduml' => true,
+        'struct' => true,
+        'typedef' => true,
     );
 
     /**


### PR DESCRIPTION
What about adding `@type` too? It has been removed from the PSR-5 draft but is already used in the wild (for instance: https://github.com/milesj/decoda/pull/71).