### PR TITLE
Add $context property to annotation constructor

### DIFF
--- a/lib/Doctrine/Common/Annotations/DocParser.php
+++ b/lib/Doctrine/Common/Annotations/DocParser.php
@@ -791,7 +791,7 @@ final class DocParser
         // check if the annotation expects values via the constructor,
         // or directly injected into public properties
         if (self::$annotationMetadata[$name]['has_constructor'] === true) {
-            return new $name($values);
+            return new $name($values, $this->context);
         }
 
         $instance = new $name();


### PR DESCRIPTION
For some purpose we need to detect annotation target, class or property name.
for sample , in a Column annotation that has a tableName property i want to create this property if it not set by user from class property name.

```php
class Blog {
       /** @Column **/
       protected $AuthorId;
}

/**
 * @Annotation
 * @Target({ "PROPERTY" })
 */
class Column {
      public $tableName;
      public __construct( array $values , $context ) {
             $propertyName = substr( $context , strpos( $context , '$' ) + 1 );
             // Convert "AuthorId" to "author_id"
             $this->tableName = String::underscore( $propertyName );
      } 
}
```