### PR TITLE
Support of inherited annotations from parent method

### DIFF
--- a/lib/Doctrine/Common/Annotations/Annotation/InheritDoc.php
+++ b/lib/Doctrine/Common/Annotations/Annotation/InheritDoc.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: avasilenko
+ * Date: 09/04/15
+ * Time: 15:28
+ */
+
+namespace Doctrine\Common\Annotations\Annotation;
+
+
+/**
+ * Annotation that signals to merge annotations from parent method/class with any found in this method/class
+ * @Annotation
+ */
+final class InheritDoc
+{
+
+}

--- a/tests/Doctrine/Tests/Common/Annotations/AnnotationReaderTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/AnnotationReaderTest.php
@@ -56,4 +56,23 @@ class AnnotationReaderTest extends AbstractReaderTest
         $this->assertInstanceOf('Doctrine\Tests\Common\Annotations\Fixtures\Annotation\Autoload', $annotations[0]);
     }
 
+    public function testInheritedMethodAnnotationViaInheritDoc()
+    {
+        $reader = $this->getReader();
+        $ref = new \ReflectionClass('Doctrine\Tests\Common\Annotations\Fixtures\ClassWithInheritedMethodAnnotation');
+
+        $annotations = $reader->getMethodAnnotations($ref->getMethod('methodWithAnnotation'));
+        $this->assertEquals(1, count($annotations));
+        $this->assertInstanceOf('Doctrine\Tests\Common\Annotations\Fixtures\AnnotationTargetMethod', $annotations[0]);
+    }
+
+    public function testInheritedMethodAnnotationViaEmptyDocComment()
+    {
+        $reader = $this->getReader();
+        $ref = new \ReflectionClass('Doctrine\Tests\Common\Annotations\Fixtures\ClassWithInheritedMethodAnnotation');
+
+        $annotations = $reader->getMethodAnnotations($ref->getMethod('anotherMethodWithAnnotation'));
+        $this->assertEquals(1, count($annotations));
+        $this->assertInstanceOf('Doctrine\Tests\Common\Annotations\Fixtures\AnnotationTargetMethod', $annotations[0]);
+    }
 }

--- a/tests/Doctrine/Tests/Common/Annotations/Fixtures/ClassWithInheritedMethodAnnotation.php
+++ b/tests/Doctrine/Tests/Common/Annotations/Fixtures/ClassWithInheritedMethodAnnotation.php
@@ -1,0 +1,17 @@
+<?php
+namespace Doctrine\Tests\Common\Annotations\Fixtures;
+
+class ClassWithInheritedMethodAnnotation extends ClassWithMethodAnnotation
+{
+    /**
+     * @inheritdoc
+     */
+    public function methodWithAnnotation()
+    {
+    }
+
+    public function anotherMethodWithAnnotation()
+    {
+        parent::anotherMethodWithAnnotation();
+    }
+}

--- a/tests/Doctrine/Tests/Common/Annotations/Fixtures/ClassWithMethodAnnotation.php
+++ b/tests/Doctrine/Tests/Common/Annotations/Fixtures/ClassWithMethodAnnotation.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Doctrine\Tests\Common\Annotations\Fixtures;
+
+class ClassWithMethodAnnotation
+{
+    /**
+     * @AnnotationTargetMethod
+     */
+    public function methodWithAnnotation(){}
+
+    /**
+     * @AnnotationTargetMethod
+     */
+    public function anotherMethodWithAnnotation(){}
+}


### PR DESCRIPTION
Hello!

This PR adds support for inherited annotations in following cases:

* method doc comment is empty
* method doc comment contains `@inheritDoc`

In second case annotations will be merged from parent and current methods. I've doubts regarding first case as it can be a big BC in certain ways.

Please let me know what you think about it.

Regards,
Alex