### PR TITLE
Allow SimpleAnnotationReader to use the global ignores

### DIFF
--- a/lib/Doctrine/Common/Annotations/AnnotationReader.php
+++ b/lib/Doctrine/Common/Annotations/AnnotationReader.php
@@ -113,6 +113,16 @@ class AnnotationReader implements Reader
     }
 
     /**
+     * Gets the globally ignored annotation names.
+     *
+     * @return array An array of Annotation names to ignore.
+     */
+    static public function getGlobalIgnoredNames()
+    {
+        return self::$globalIgnoredNames;
+    }
+
+    /**
      * Annotations parser.
      *
      * @var \Doctrine\Common\Annotations\DocParser

--- a/lib/Doctrine/Common/Annotations/DocParser.php
+++ b/lib/Doctrine/Common/Annotations/DocParser.php
@@ -672,7 +672,7 @@ final class DocParser
             $alias = (false === $pos = strpos($name, '\\'))? $name : substr($name, 0, $pos);
             $found = false;
 
-            if ($this->namespaces) {
+            if ( ! isset($this->ignoredAnnotationNames[$name]) && $this->namespaces) {
                 foreach ($this->namespaces as $namespace) {
                     if ($this->classExists($namespace.'\\'.$name)) {
                         $name = $namespace.'\\'.$name;

--- a/lib/Doctrine/Common/Annotations/SimpleAnnotationReader.php
+++ b/lib/Doctrine/Common/Annotations/SimpleAnnotationReader.php
@@ -45,6 +45,7 @@ class SimpleAnnotationReader implements Reader
     {
         $this->parser = new DocParser();
         $this->parser->setIgnoreNotImportedAnnotations(true);
+        $this->parser->setIgnoredAnnotationNames(AnnotationReader::getGlobalIgnoredNames());
     }
 
     /**

--- a/tests/Doctrine/Tests/Common/Annotations/SimpleAnnotationReaderTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/SimpleAnnotationReaderTest.php
@@ -85,9 +85,9 @@ class SimpleAnnotationReaderTest extends AbstractReaderTest
         $class  = new \ReflectionClass('Doctrine\Tests\Common\Annotations\Fixtures\ClassDDC1660');
 
         $this->assertTrue(class_exists('Doctrine\Tests\Common\Annotations\Fixtures\Annotation\Version'));
-        $this->assertCount(1, $reader->getClassAnnotations($class));
-        $this->assertCount(1, $reader->getMethodAnnotations($class->getMethod('bar')));
-        $this->assertCount(1, $reader->getPropertyAnnotations($class->getProperty('foo')));
+        $this->assertCount(0, $reader->getClassAnnotations($class));
+        $this->assertCount(0, $reader->getMethodAnnotations($class->getMethod('bar')));
+        $this->assertCount(0, $reader->getPropertyAnnotations($class->getProperty('foo')));
     }
 
     protected function getReader()


### PR DESCRIPTION
Whilst having a look at the classmap Drupal 8 generates I noticed we had a lot of classes called "see" in different namespaces. All mapped to NULL - ie. they don't exist. I tracked this down to the SimpleAnnotationReader finding doc blocks with @see annotations. The regular AnnotationReader ignores these so shouldn't the SimpleAnnotationReader too?