### PR TITLE
Switch to the docker-based infrastructure on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 language: php
 
+sudo: false
+
+cache:
+  directory:
+    - $HOME/.composer/cache
+
 php:
   - 5.3
   - 5.4
@@ -8,4 +14,4 @@ php:
   - hhvm
 
 before_script:
-    - composer --prefer-source --dev install
+    - composer install -n


### PR DESCRIPTION
This infrastructure is faster and allows to use the composer cache.