### PR TITLE
opcache.load_comments has been removed from PHP 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7
   - hhvm
 
 before_script:

--- a/lib/Doctrine/Common/Annotations/AnnotationReader.php
+++ b/lib/Doctrine/Common/Annotations/AnnotationReader.php
@@ -162,13 +162,14 @@ class AnnotationReader implements Reader
             throw AnnotationException::optimizerPlusSaveComments();
         }
 
+        if (PHP_VERSION < 70000) {
+            if (extension_loaded('Zend Optimizer+') && (ini_get('zend_optimizerplus.load_comments') === "0" || ini_get('opcache.load_comments') === "0")) {
+                throw AnnotationException::optimizerPlusLoadComments();
+            }
 
-        if (extension_loaded('Zend Optimizer+') && (ini_get('zend_optimizerplus.load_comments') === "0" || ini_get('opcache.load_comments') === "0")) {
-            throw AnnotationException::optimizerPlusLoadComments();
-        }
-
-        if (extension_loaded('Zend OPcache') && ini_get('opcache.load_comments') == 0) {
-            throw AnnotationException::optimizerPlusLoadComments();
+            if (extension_loaded('Zend OPcache') && ini_get('opcache.load_comments') == 0) {
+                throw AnnotationException::optimizerPlusLoadComments();
+            }
         }
 
         AnnotationRegistry::registerFile(__DIR__ . '/Annotation/IgnoreAnnotation.php');

--- a/lib/Doctrine/Common/Annotations/AnnotationReader.php
+++ b/lib/Doctrine/Common/Annotations/AnnotationReader.php
@@ -162,7 +162,7 @@ class AnnotationReader implements Reader
             throw AnnotationException::optimizerPlusSaveComments();
         }
 
-        if (PHP_VERSION < 70000) {
+        if (PHP_VERSION_ID < 70000) {
             if (extension_loaded('Zend Optimizer+') && (ini_get('zend_optimizerplus.load_comments') === "0" || ini_get('opcache.load_comments') === "0")) {
                 throw AnnotationException::optimizerPlusLoadComments();
             }

--- a/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
@@ -1180,6 +1180,11 @@ DOCBLOCK;
 
     public function testReservedKeywordsInAnnotations()
     {
+        if (PHP_VERSION_ID >= 70000) {
+            $this->markTestSkipped('This test requires PHP 5.6 or lower.');
+        }
+        require 'ReservedKeywordsClasses.php';
+
         $parser = $this->createTestParser();
 
         $result = $parser->parse('@Doctrine\Tests\Common\Annotations\True');
@@ -1355,15 +1360,6 @@ class Name extends \Doctrine\Common\Annotations\Annotation {
 class Marker {
     public $value;
 }
-
-/** @Annotation */
-class True {}
-
-/** @Annotation */
-class False {}
-
-/** @Annotation */
-class Null {}
 
 namespace Doctrine\Tests\Common\Annotations\FooBar;
 

--- a/tests/Doctrine/Tests/Common/Annotations/ReservedKeywordsClasses.php
+++ b/tests/Doctrine/Tests/Common/Annotations/ReservedKeywordsClasses.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Doctrine\Tests\Common\Annotations;
+
+/** @Annotation */
+class True {}
+
+/** @Annotation */
+class False {}
+
+/** @Annotation */
+class Null {}


### PR DESCRIPTION
When building a very fresh php7 version from source this morning, it appeared that one of my projects using doctrine/annotations didn't work anymore.

It seems that the support of this option has been removed from php7, see https://github.com/php/php-src/commit/0a21a0c752a06d25704e04c15464700f75164849

I don't know if this will be backported to php5.6 and/or 5.5 for the moment.

This PR simply checks the php version before checking the value of opcache.load_comments.