### PR TITLE
[CachedReader] Test traits and parent class to see if cache is fresh

### DIFF
--- a/tests/Doctrine/Tests/Common/Annotations/Fixtures/AbstractController.php
+++ b/tests/Doctrine/Tests/Common/Annotations/Fixtures/AbstractController.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Doctrine\Tests\Common\Annotations\Fixtures;
+
+abstract class AbstractController
+{
+}

--- a/tests/Doctrine/Tests/Common/Annotations/Fixtures/ControllerWithParentClass.php
+++ b/tests/Doctrine/Tests/Common/Annotations/Fixtures/ControllerWithParentClass.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Doctrine\Tests\Common\Annotations\Fixtures;
+
+use Doctrine\Tests\Common\Annotations\Fixtures\Annotation\Template;
+use Doctrine\Tests\Common\Annotations\Fixtures\Annotation\Route;
+
+/**
+ * @Route("/someprefix")
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ */
+class ControllerWithParentClass extends AbstractController
+{
+    /**
+     * @Route("/", name="_demo")
+     * @Template()
+     */
+    public function indexAction()
+    {
+        return array();
+    }
+}

--- a/tests/Doctrine/Tests/Common/Annotations/Fixtures/ControllerWithTrait.php
+++ b/tests/Doctrine/Tests/Common/Annotations/Fixtures/ControllerWithTrait.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Doctrine\Tests\Common\Annotations\Fixtures;
+
+use Doctrine\Tests\Common\Annotations\Fixtures\Annotation\Template;
+use Doctrine\Tests\Common\Annotations\Fixtures\Annotation\Route;
+use Doctrine\Tests\Common\Annotations\Fixtures\Traits\SecretRouteTrait;
+
+/**
+ * @Route("/someprefix")
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ */
+class ControllerWithTrait
+{
+    use SecretRouteTrait;
+
+    /**
+     * @Route("/", name="_demo")
+     * @Template()
+     */
+    public function indexAction()
+    {
+        return array();
+    }
+}

--- a/tests/Doctrine/Tests/Common/Annotations/Fixtures/Traits/SecretRouteTrait.php
+++ b/tests/Doctrine/Tests/Common/Annotations/Fixtures/Traits/SecretRouteTrait.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Doctrine\Tests\Common\Annotations\Fixtures\Traits;
+
+use Doctrine\Tests\Common\Annotations\Fixtures\Annotation\Template;
+use Doctrine\Tests\Common\Annotations\Fixtures\Annotation\Route;
+
+trait SecretRouteTrait
+{
+    /**
+     * @Route("/secret", name="_secret")
+     * @Template()
+     */
+    public function secretAction()
+    {
+        return array();
+    }
+}


### PR DESCRIPTION
This PR is useful if for exemple you work with traits in your entities or with a parent class.
Before, the cache was not refreshed when you made changes in traits or parent class.
