### PR TITLE
Remove cache salt making key unnecessarily long

### DIFF
--- a/lib/Doctrine/Common/Annotations/CachedReader.php
+++ b/lib/Doctrine/Common/Annotations/CachedReader.php
@@ -30,11 +30,6 @@ use Doctrine\Common\Cache\Cache;
 final class CachedReader implements Reader
 {
     /**
-     * @var string
-     */
-    private static $CACHE_SALT = '@[Annot]';
-
-    /**
      * @var Reader
      */
     private $delegate;
@@ -182,14 +177,13 @@ final class CachedReader implements Reader
     /**
      * Fetches a value from the cache.
      *
-     * @param string           $rawCacheKey The cache key.
-     * @param \ReflectionClass $class       The related class.
+     * @param string           $cacheKey The cache key.
+     * @param \ReflectionClass $class    The related class.
      *
      * @return mixed The cached value or false when the value is not in cache.
      */
-    private function fetchFromCache($rawCacheKey, \ReflectionClass $class)
+    private function fetchFromCache($cacheKey, \ReflectionClass $class)
     {
-        $cacheKey = $rawCacheKey . self::$CACHE_SALT;
         if (($data = $this->cache->fetch($cacheKey)) !== false) {
             if (!$this->debug || $this->isCacheFresh($cacheKey, $class)) {
                 return $data;
@@ -202,14 +196,13 @@ final class CachedReader implements Reader
     /**
      * Saves a value to the cache.
      *
-     * @param string $rawCacheKey The cache key.
-     * @param mixed  $value       The value.
+     * @param string $cacheKey The cache key.
+     * @param mixed  $value    The value.
      *
      * @return void
      */
-    private function saveToCache($rawCacheKey, $value)
+    private function saveToCache($cacheKey, $value)
     {
-        $cacheKey = $rawCacheKey . self::$CACHE_SALT;
         $this->cache->save($cacheKey, $value);
         if ($this->debug) {
             $this->cache->save('[C]'.$cacheKey, time());

--- a/tests/Doctrine/Tests/Common/Annotations/CachedReaderTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/CachedReaderTest.php
@@ -16,7 +16,7 @@ class CachedReaderTest extends AbstractReaderTest
         $file = __DIR__.'/Fixtures/Controller.php';
         touch($file);
         $name = 'Doctrine\Tests\Common\Annotations\Fixtures\Controller';
-        $cacheKey = $name.'@[Annot]';
+        $cacheKey = $name;
 
         $cache = $this->getMock('Doctrine\Common\Cache\Cache');
         $cache


### PR DESCRIPTION
The salt just makes the key unnecessarily long and some caches have a limit in the length of the cache key or long keys just make it slower or require more space.
The cache key must only be unique within its own domain. If one uses a shared cache, that's where namespaces are used. These are also supported by the doctrine cache. So adding a salt as well makes no sense.
For a concrete problem I found due to long cache key, see https://github.com/doctrine/cache/pull/107 