### PR TITLE
Fix of incorrect parsing multibyte strings

### DIFF
--- a/lib/Doctrine/Common/Annotations/DocParser.php
+++ b/lib/Doctrine/Common/Annotations/DocParser.php
@@ -347,8 +347,9 @@ final class DocParser
 
         // search for first valid annotation
         while (($pos = strpos($input, '@', $pos)) !== false) {
+            $preceding = substr($input, $pos - 1, 1);
             // if the @ is preceded by a space or * it is valid
-            if ($pos === 0 || $input[$pos - 1] === ' ' || $input[$pos - 1] === '*') {
+            if ($pos === 0 || in_array($preceding, array(' ', '*'))) {
                 return $pos;
             }
 

--- a/lib/Doctrine/Common/Annotations/DocParser.php
+++ b/lib/Doctrine/Common/Annotations/DocParser.php
@@ -349,7 +349,7 @@ final class DocParser
         while (($pos = strpos($input, '@', $pos)) !== false) {
             $preceding = substr($input, $pos - 1, 1);
             // if the @ is preceded by a space or * it is valid
-            if ($pos === 0 || $preceding === ' ' || $preceding === '*')) {
+            if ($pos === 0 || $preceding === ' ' || $preceding === '*') {
                 return $pos;
             }
 

--- a/lib/Doctrine/Common/Annotations/DocParser.php
+++ b/lib/Doctrine/Common/Annotations/DocParser.php
@@ -349,7 +349,7 @@ final class DocParser
         while (($pos = strpos($input, '@', $pos)) !== false) {
             $preceding = substr($input, $pos - 1, 1);
             // if the @ is preceded by a space or * it is valid
-            if ($pos === 0 || in_array($preceding, array(' ', '*'))) {
+            if ($pos === 0 || $preceding === ' ' || $preceding === '*')) {
                 return $pos;
             }
 

--- a/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
@@ -1300,6 +1300,32 @@ DOCBLOCK;
         $this->assertTrue($result[0] instanceof Name);
         $this->assertEquals('"bar"', $result[0]->foo);
     }
+
+    /**
+     * @see http://php.net/manual/en/mbstring.configuration.php
+     * mbstring.func_overload can be changed only in php.ini
+     * so for testing this case instead of skipping it you need to manually configure your php installation
+     */
+    public function testMultiByteAnnotation()
+    {
+        $overloadStringFunctions = 2;
+        if (!extension_loaded('mbstring') || (ini_get("mbstring.func_overload") & $overloadStringFunctions) == 0) {
+            $this->markTestSkipped('This test requires mbstring function overloading is turned on');
+        }
+
+        $docblock = <<<DOCBLOCK
+        /**
+         * Мультибайтовый текст ломал парсер при оверлоадинге строковых функций
+         * @Doctrine\Tests\Common\Annotations\Name
+         */
+DOCBLOCK;
+
+        $docParser = $this->createTestParser();
+        $result = $docParser->parse($docblock);
+
+        $this->assertCount(1, $result);
+
+    }
 }
 
 /** @Annotation */


### PR DESCRIPTION
If function overloading for mb_string (http://php.net/manual/en/mbstring.overload.php) is turned on then reading of annotations with unicode strings works incorrect.
Just don't use array access for string next time :)