### PR TITLE
Allow tab character before first annotation in DocBlock

### DIFF
--- a/lib/Doctrine/Common/Annotations/DocParser.php
+++ b/lib/Doctrine/Common/Annotations/DocParser.php
@@ -348,7 +348,7 @@ final class DocParser
         // search for first valid annotation
         while (($pos = strpos($input, '@', $pos)) !== false) {
             // if the @ is preceded by a space or * it is valid
-            if ($pos === 0 || $input[$pos - 1] === ' ' || $input[$pos - 1] === '*') {
+            if ($pos === 0 || $input[$pos - 1] === ' ' || $input[$pos - 1] === "\t" || $input[$pos - 1] === '*') {
                 return $pos;
             }
 

--- a/lib/Doctrine/Common/Annotations/DocParser.php
+++ b/lib/Doctrine/Common/Annotations/DocParser.php
@@ -347,7 +347,7 @@ final class DocParser
 
         // search for first valid annotation
         while (($pos = strpos($input, '@', $pos)) !== false) {
-            // if the @ is preceded by a space or * it is valid
+            // if the @ is preceded by a space, tab, or * it is valid
             if ($pos === 0 || $input[$pos - 1] === ' ' || $input[$pos - 1] === "\t" || $input[$pos - 1] === '*') {
                 return $pos;
             }

--- a/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
@@ -1249,9 +1249,9 @@ DOCBLOCK;
 
         $parser = $this->createTestParser();
         $result = $parser->parse($docblock);
-        $this->assertEquals(1, count($result));
+        $this->assertCount(1, $result);
         $annot = $result[0];
-        $this->assertTrue($annot instanceof Name);
+        $this->assertInstanceOf('Name', $annot);
     }
 
     public function testDefaultAnnotationValueIsNotOverwritten()

--- a/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
@@ -1251,7 +1251,7 @@ DOCBLOCK;
         $result = $parser->parse($docblock);
         $this->assertCount(1, $result);
         $annot = $result[0];
-        $this->assertInstanceOf('Name', $annot);
+        $this->assertInstanceOf('Doctrine\Tests\Common\Annotations\Name', $annot);
     }
 
     public function testDefaultAnnotationValueIsNotOverwritten()

--- a/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
@@ -1239,6 +1239,21 @@ DOCBLOCK;
         $this->assertEquals(array('Foo', 'Bar'), $annots[0]->value);
     }
 
+    public function testTabPrefixIsAllowed()
+    {
+        $docblock = <<<DOCBLOCK
+/**
+ *	@Name
+ */
+DOCBLOCK;
+
+        $parser = $this->createTestParser();
+        $result = $parser->parse($docblock);
+        $this->assertEquals(1, count($result));
+        $annot = $result[0];
+        $this->assertTrue($annot instanceof Name);
+    }
+
     public function testDefaultAnnotationValueIsNotOverwritten()
     {
         $parser = $this->createTestParser();


### PR DESCRIPTION
https://github.com/doctrine/annotations/issues/68