### PR TITLE
Ignore not registered annotations fix

### DIFF
--- a/lib/Doctrine/Common/Annotations/AnnotationReader.php
+++ b/lib/Doctrine/Common/Annotations/AnnotationReader.php
@@ -153,7 +153,6 @@ class AnnotationReader implements Reader
      * Initializes a new AnnotationReader.
      *
      * @param DocParser $parser
-     * @throws AnnotationException
      */
     public function __construct(DocParser $parser = null)
     {
@@ -177,7 +176,7 @@ class AnnotationReader implements Reader
 
         AnnotationRegistry::registerFile(__DIR__ . '/Annotation/IgnoreAnnotation.php');
 
-        $this->parser = is_null($parser) ? new DocParser() : $parser;
+        $this->parser = (null === $parser) ? new DocParser() : $parser;
 
         $this->preParser = new DocParser;
 

--- a/lib/Doctrine/Common/Annotations/AnnotationReader.php
+++ b/lib/Doctrine/Common/Annotations/AnnotationReader.php
@@ -176,7 +176,7 @@ class AnnotationReader implements Reader
 
         AnnotationRegistry::registerFile(__DIR__ . '/Annotation/IgnoreAnnotation.php');
 
-        $this->parser = (null === $parser) ? new DocParser() : $parser;
+        $this->parser = $parser ?: new DocParser();
 
         $this->preParser = new DocParser;
 

--- a/lib/Doctrine/Common/Annotations/AnnotationReader.php
+++ b/lib/Doctrine/Common/Annotations/AnnotationReader.php
@@ -184,6 +184,14 @@ class AnnotationReader implements Reader
     }
 
     /**
+     * @param bool $notImportedAnnotationsIgnored
+     */
+    public function setParserIgnoreNotImportedAnnotations($notImportedAnnotationsIgnored)
+    {
+        $this->parser->setIgnoreNotImportedAnnotations($notImportedAnnotationsIgnored);
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function getClassAnnotations(ReflectionClass $class)

--- a/lib/Doctrine/Common/Annotations/AnnotationReader.php
+++ b/lib/Doctrine/Common/Annotations/AnnotationReader.php
@@ -151,8 +151,11 @@ class AnnotationReader implements Reader
      * Constructor.
      *
      * Initializes a new AnnotationReader.
+     *
+     * @param DocParser $parser
+     * @throws AnnotationException
      */
-    public function __construct()
+    public function __construct(DocParser $parser = null)
     {
         if (extension_loaded('Zend Optimizer+') && (ini_get('zend_optimizerplus.save_comments') === "0" || ini_get('opcache.save_comments') === "0")) {
             throw AnnotationException::optimizerPlusSaveComments();
@@ -174,21 +177,14 @@ class AnnotationReader implements Reader
 
         AnnotationRegistry::registerFile(__DIR__ . '/Annotation/IgnoreAnnotation.php');
 
-        $this->parser    = new DocParser;
+        $this->parser = is_null($parser) ? new DocParser() : $parser;
+
         $this->preParser = new DocParser;
 
         $this->preParser->setImports(self::$globalImports);
         $this->preParser->setIgnoreNotImportedAnnotations(true);
 
         $this->phpParser = new PhpParser;
-    }
-
-    /**
-     * @param bool $notImportedAnnotationsIgnored
-     */
-    public function setParserIgnoreNotImportedAnnotations($notImportedAnnotationsIgnored)
-    {
-        $this->parser->setIgnoreNotImportedAnnotations($notImportedAnnotationsIgnored);
     }
 
     /**

--- a/tests/Doctrine/Tests/Common/Annotations/AnnotationReaderTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/AnnotationReaderTest.php
@@ -3,12 +3,17 @@
 namespace Doctrine\Tests\Common\Annotations;
 
 use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\Annotations\DocParser;
 
 class AnnotationReaderTest extends AbstractReaderTest
 {
-    protected function getReader()
+    /**
+     * @param DocParser|null $parser
+     * @return AnnotationReader
+     */
+    protected function getReader(DocParser $parser = null)
     {
-        return new AnnotationReader();
+        return new AnnotationReader($parser);
     }
 
     public function testMethodAnnotationFromTrait()
@@ -58,8 +63,10 @@ class AnnotationReaderTest extends AbstractReaderTest
 
     public function testOmitNotRegisteredAnnotation()
     {
-        $reader = $this->getReader();
-        $reader->setParserIgnoreNotImportedAnnotations(true);
+        $parser = new DocParser();
+        $parser->setIgnoreNotImportedAnnotations(true);
+
+        $reader = $this->getReader($parser);
         $ref = new \ReflectionClass('Doctrine\Tests\Common\Annotations\Fixtures\ClassWithNotRegisteredAnnotationUsed');
 
         $annotations = $reader->getMethodAnnotations($ref->getMethod('methodWithNotRegisteredAnnotation'));

--- a/tests/Doctrine/Tests/Common/Annotations/AnnotationReaderTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/AnnotationReaderTest.php
@@ -63,6 +63,6 @@ class AnnotationReaderTest extends AbstractReaderTest
         $ref = new \ReflectionClass('Doctrine\Tests\Common\Annotations\Fixtures\ClassWithNotRegisteredAnnotationUsed');
 
         $annotations = $reader->getMethodAnnotations($ref->getMethod('methodWithNotRegisteredAnnotation'));
-        $this->assertEquals([], $annotations);
+        $this->assertEquals(array(), $annotations);
     }
 }

--- a/tests/Doctrine/Tests/Common/Annotations/AnnotationReaderTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/AnnotationReaderTest.php
@@ -56,4 +56,13 @@ class AnnotationReaderTest extends AbstractReaderTest
         $this->assertInstanceOf('Doctrine\Tests\Common\Annotations\Fixtures\Annotation\Autoload', $annotations[0]);
     }
 
+    public function testOmitNotRegisteredAnnotation()
+    {
+        $reader = $this->getReader();
+        $reader->setParserIgnoreNotImportedAnnotations(true);
+        $ref = new \ReflectionClass('Doctrine\Tests\Common\Annotations\Fixtures\ClassWithNotRegisteredAnnotationUsed');
+
+        $annotations = $reader->getMethodAnnotations($ref->getMethod('methodWithNotRegisteredAnnotation'));
+        $this->assertEquals([], $annotations);
+    }
 }

--- a/tests/Doctrine/Tests/Common/Annotations/Fixtures/ClassWithNotRegisteredAnnotationUsed.php
+++ b/tests/Doctrine/Tests/Common/Annotations/Fixtures/ClassWithNotRegisteredAnnotationUsed.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Doctrine\Tests\Common\Annotations\Fixtures;
+
+/**
+ * Class ClassWithNotRegisteredAnnotationUsed
+ * @package Doctrine\Tests\Common\Annotations\Fixtures
+ */
+class ClassWithNotRegisteredAnnotationUsed
+{
+    /**
+     * @notRegisteredCustomAnnotation
+     * @return bool
+     */
+    public function methodWithNotRegisteredAnnotation()
+    {
+        return false;
+    }
+}


### PR DESCRIPTION
Ignore not registered annotations without adding them to global ignore list