### PR TITLE
Fix: Use SVG badge for Travis build status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Doctrine Annotations
 
-[![Build Status](https://travis-ci.org/doctrine/annotations.png?branch=master)](https://travis-ci.org/doctrine/annotations)
+[![Build Status](https://travis-ci.org/doctrine/annotations.svg?branch=master)](https://travis-ci.org/doctrine/annotations)
 
 Docblock Annotations Parser library (extracted from [Doctrine Common](https://github.com/doctrine/common)).
 


### PR DESCRIPTION
This PR

* [x] uses an SVG badge for displaying the Travis build status

:information_desk_person: It's more pleasing to the eye.