### PR TITLE
Parse parent classes too while fetching imports.

### DIFF
--- a/lib/Doctrine/Common/Annotations/PhpParser.php
+++ b/lib/Doctrine/Common/Annotations/PhpParser.php
@@ -58,6 +58,11 @@ final class PhpParser
 
         $statements = $tokenizer->parseUseStatements($class->getNamespaceName());
 
+        while ($parent = $class->getParentClass()) {
+            $statements = array_merge($statements, $this->parseClass($parent));
+            $class = $parent;
+        }
+
         return $statements;
     }
 

--- a/tests/Doctrine/Tests/Common/Annotations/Fixtures/ChildClassInheritingFromParentClass.php
+++ b/tests/Doctrine/Tests/Common/Annotations/Fixtures/ChildClassInheritingFromParentClass.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Doctrine\Tests\Common\Annotations\Fixtures;
+
+class ChildClassInheritingFromParentClass extends ParentClassWithAnnotatedMethod
+{
+
+}

--- a/tests/Doctrine/Tests/Common/Annotations/Fixtures/ParentClassWithAnnotatedMethod.php
+++ b/tests/Doctrine/Tests/Common/Annotations/Fixtures/ParentClassWithAnnotatedMethod.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Doctrine\Tests\Common\Annotations\Fixtures;
+
+use Doctrine\Tests\Common\Annotations\Fixtures\Annotation\Autoload;
+
+class ParentClassWithAnnotatedMethod
+{
+
+    /**
+     * @Autoload
+     */
+    public function someMethod()
+    {
+
+    }
+}

--- a/tests/Doctrine/Tests/Common/Annotations/PhpParserTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/PhpParserTest.php
@@ -204,4 +204,17 @@ class PhpParserTest extends \PHPUnit_Framework_TestCase
           'annotationtargetannotation'  => __NAMESPACE__ . '\Fixtures\AnnotationTargetAnnotation',
         ), $parser->parseClass($class));
     }
+
+    public function testParseChildClassForInheritedMethod()
+    {
+        $parser = new PhpParser();
+
+        // ChildClassInheritingFromParentClass extends ParentClassWithAnnotatedMethod
+        $class = new ReflectionClass(__NAMESPACE__ . '\Fixtures\ChildClassInheritingFromParentClass');
+
+        // @Autoload annotation should be found within ParentClassWithAnnotatedMethod
+        $this->assertEquals(array(
+            'autoload' => __NAMESPACE__ . '\Fixtures\Annotation\Autoload',
+        ), $parser->parseClass($class));
+    }
 }


### PR DESCRIPTION
When parsing imports for a specific class, the imports of all its parent classes need to be parsed too, or else the `AnnotationReader` might throw erroneous exceptions when methods from a parent class are called, because the import of the annotation could be ina parent class' `use` statements without appearing in the child class' `use` statement.

See #79
