### PR TITLE
Fix - #70 - allow tab character before first annotation in docblock

### DIFF
--- a/lib/Doctrine/Common/Annotations/DocParser.php
+++ b/lib/Doctrine/Common/Annotations/DocParser.php
@@ -368,8 +368,9 @@ final class DocParser
         // search for first valid annotation
         while (($pos = strpos($input, '@', $pos)) !== false) {
             $preceding = substr($input, $pos - 1, 1);
-            // if the @ is preceded by a space or * it is valid
-            if ($pos === 0 || $preceding === ' ' || $preceding === '*') {
+
+            // if the @ is preceded by a space, a tab or * it is valid
+            if ($pos === 0 || $preceding === ' ' || $preceding === '*' || $preceding === "\t") {
                 return $pos;
             }
 

--- a/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
@@ -1294,7 +1294,7 @@ DOCBLOCK;
         $result = $parser->parse($docblock);
         $this->assertCount(1, $result);
         $annot = $result[0];
-        $this->assertInstanceOf('Name', $annot);
+        $this->assertInstanceOf('Doctrine\Tests\Common\Annotations\Name', $annot);
     }
 
     public function testDefaultAnnotationValueIsNotOverwritten()

--- a/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
@@ -1292,9 +1292,9 @@ DOCBLOCK;
 
         $parser = $this->createTestParser();
         $result = $parser->parse($docblock);
-        $this->assertEquals(1, count($result));
+        $this->assertCount(1, $result);
         $annot = $result[0];
-        $this->assertTrue($annot instanceof Name);
+        $this->assertInstanceOf('Name', $annot);
     }
 
     public function testDefaultAnnotationValueIsNotOverwritten()

--- a/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
@@ -1293,8 +1293,7 @@ DOCBLOCK;
         $parser = $this->createTestParser();
         $result = $parser->parse($docblock);
         $this->assertCount(1, $result);
-        $annot = $result[0];
-        $this->assertInstanceOf('Doctrine\Tests\Common\Annotations\Name', $annot);
+        $this->assertInstanceOf('Doctrine\Tests\Common\Annotations\Name', $result[0]);
     }
 
     public function testDefaultAnnotationValueIsNotOverwritten()

--- a/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
@@ -1282,6 +1282,21 @@ DOCBLOCK;
         $this->assertEquals(array('Foo', 'Bar'), $annots[0]->value);
     }
 
+    public function testTabPrefixIsAllowed()
+    {
+        $docblock = <<<DOCBLOCK
+/**
+ *	@Name
+ */
+DOCBLOCK;
+
+        $parser = $this->createTestParser();
+        $result = $parser->parse($docblock);
+        $this->assertEquals(1, count($result));
+        $annot = $result[0];
+        $this->assertTrue($annot instanceof Name);
+    }
+
     public function testDefaultAnnotationValueIsNotOverwritten()
     {
         $parser = $this->createTestParser();


### PR DESCRIPTION
Continuation/rebase of #70 

Fixes #68