### PR TITLE
Test annotation parameters containing space

### DIFF
--- a/tests/Doctrine/Tests/Common/Annotations/AbstractReaderTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/AbstractReaderTest.php
@@ -55,6 +55,9 @@ abstract class AbstractReaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('', $dummyAnnot->dummyValue);
         $this->assertEquals(array(1, 2, 'three'), $dummyAnnot->value);
 
+        $dummyAnnot = $reader->getMethodAnnotation($class->getMethod('getField3'), 'Doctrine\Tests\Common\Annotations\DummyAnnotation');
+        $this->assertEquals('\d{4}-[01]\d-[0-3]\d [0-2]\d:[0-5]\d:[0-5]\d', $dummyAnnot->value);
+
         $dummyAnnot = $reader->getPropertyAnnotation($class->getProperty('field1'), 'Doctrine\Tests\Common\Annotations\DummyAnnotation');
         $this->assertEquals('fieldHello', $dummyAnnot->dummyValue);
 

--- a/tests/Doctrine/Tests/Common/Annotations/DummyClass.php
+++ b/tests/Doctrine/Tests/Common/Annotations/DummyClass.php
@@ -45,4 +45,13 @@ class DummyClass
     public function getField1()
     {
     }
+
+    /**
+     * A parameter value with a space in it.
+     *
+     * @DummyAnnotation("\d{4}-[01]\d-[0-3]\d [0-2]\d:[0-5]\d:[0-5]\d")
+     */
+    public function getField3()
+    {
+    }
 }


### PR DESCRIPTION
Apparently this used to be a problem but I couldn't
find a test that covered this specific case.