### PR TITLE
Fix for issue #81 Traits Composed from Traits

### DIFF
--- a/tests/Doctrine/Tests/Common/Annotations/AnnotationReaderTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/AnnotationReaderTest.php
@@ -4,6 +4,8 @@ namespace Doctrine\Tests\Common\Annotations;
 
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Annotations\DocParser;
+use Doctrine\Tests\Common\Annotations\Fixtures\Annotation\Autoload;
+use Doctrine\Tests\Common\Annotations\Fixtures\Annotation\Version;
 use Doctrine\Tests\Common\Annotations\Fixtures\IgnoredNamespaces\AnnotatedAtClassLevel;
 use Doctrine\Tests\Common\Annotations\Fixtures\IgnoredNamespaces\AnnotatedAtMethodLevel;
 use Doctrine\Tests\Common\Annotations\Fixtures\IgnoredNamespaces\AnnotatedAtPropertyLevel;
@@ -49,6 +51,35 @@ class AnnotationReaderTest extends AbstractReaderTest
         $this->assertInstanceOf('Doctrine\Tests\Common\Annotations\Bar\Autoload', $annotations[0]);
 
         $annotations = $reader->getPropertyAnnotations($ref->getProperty('traitProperty'));
+        $this->assertInstanceOf('Doctrine\Tests\Common\Annotations\Fixtures\Annotation\Autoload', $annotations[0]);
+    }
+
+    public function testPropertyAnnotationFromTraitThatUsesAnotherTrait()
+    {
+        $reader = $this->getReader();
+        $ref =
+            new \ReflectionClass('Doctrine\Tests\Common\Annotations\Fixtures\ClassThatUsesTraitThatUsesAnotherTrait');
+
+        $annotations = $reader->getPropertyAnnotations($ref->getProperty('route'));
+        $this->assertInstanceOf(Version::class, $annotations[0]);
+
+        $annotations = $reader->getPropertyAnnotations($ref->getProperty('intermediate'));
+        $this->assertInstanceOf(Autoload::class, $annotations[0]);
+    }
+
+    public function testMethodAnnotationFromTraitThatUsesAnotherTrait()
+    {
+        $reader = $this->getReader();
+        $ref =
+            new \ReflectionClass('Doctrine\Tests\Common\Annotations\Fixtures\ClassThatUsesTraitThatUsesAnotherTrait');
+
+        $annotations = $reader->getMethodAnnotations($ref->getMethod('secretAction'));
+        $this->assertInstanceOf('Doctrine\Tests\Common\Annotations\Fixtures\Annotation\Route', $annotations[0]);
+
+        $annotations = $reader->getMethodAnnotations($ref->getMethod('conflict'));
+        $this->assertInstanceOf('Doctrine\Tests\Common\Annotations\Fixtures\Annotation\Template', $annotations[0]);
+
+        $annotations = $reader->getMethodAnnotations($ref->getMethod('noConflict'));
         $this->assertInstanceOf('Doctrine\Tests\Common\Annotations\Fixtures\Annotation\Autoload', $annotations[0]);
     }
 

--- a/tests/Doctrine/Tests/Common/Annotations/Fixtures/Traits/ConflictTraitA.php
+++ b/tests/Doctrine/Tests/Common/Annotations/Fixtures/Traits/ConflictTraitA.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Doctrine\Tests\Common\Annotations\Fixtures\Traits;
+
+use Doctrine\Tests\Common\Annotations\Fixtures\Annotation\Template;
+
+trait ConflictTraitA
+{
+    /**
+     * @Template
+     */
+    public function conflict(){}
+}

--- a/tests/Doctrine/Tests/Common/Annotations/Fixtures/Traits/ConflictTraitB.php
+++ b/tests/Doctrine/Tests/Common/Annotations/Fixtures/Traits/ConflictTraitB.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Doctrine\Tests\Common\Annotations\Fixtures\Traits;
+
+use Doctrine\Tests\Common\Annotations\Fixtures\Annotation\Route;
+
+trait ConflictTraitB
+{
+    /**
+     * @Route
+     */
+    public function conflict(){}
+}

--- a/tests/Doctrine/Tests/Common/Annotations/Fixtures/Traits/ConflictTraitC.php
+++ b/tests/Doctrine/Tests/Common/Annotations/Fixtures/Traits/ConflictTraitC.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Doctrine\Tests\Common\Annotations\Fixtures\Traits;
+
+use Doctrine\Tests\Common\Annotations\Fixtures\Annotation\Autoload;
+
+trait ConflictTraitC
+{
+    /**
+     * @Autoload
+     */
+    public function conflict(){}
+}

--- a/tests/Doctrine/Tests/Common/Annotations/Fixtures/Traits/SecretRouteTrait.php
+++ b/tests/Doctrine/Tests/Common/Annotations/Fixtures/Traits/SecretRouteTrait.php
@@ -4,9 +4,15 @@ namespace Doctrine\Tests\Common\Annotations\Fixtures\Traits;
 
 use Doctrine\Tests\Common\Annotations\Fixtures\Annotation\Template;
 use Doctrine\Tests\Common\Annotations\Fixtures\Annotation\Route;
+use Doctrine\Tests\Common\Annotations\Fixtures\Annotation\Version as Property;
 
 trait SecretRouteTrait
 {
+    /**
+     * @Property
+     */
+    private $route;
+
     /**
      * @Route("/secret", name="_secret")
      * @Template()

--- a/tests/Doctrine/Tests/Common/Annotations/Fixtures/Traits/TraitThatUsesAnotherTrait.php
+++ b/tests/Doctrine/Tests/Common/Annotations/Fixtures/Traits/TraitThatUsesAnotherTrait.php
@@ -2,7 +2,20 @@
 
 namespace Doctrine\Tests\Common\Annotations\Fixtures\Traits;
 
+use Doctrine\Tests\Common\Annotations\Fixtures\Annotation\Autoload as In;
+
 trait TraitThatUsesAnotherTrait
 {
     use EmptyTrait;
+    use SecretRouteTrait;
+    use ConflictTraitA, ConflictTraitB, ConflictTraitC {
+        ConflictTraitA::conflict insteadof ConflictTraitB;
+        ConflictTraitA::conflict insteadOf ConflictTraitC;
+        ConflictTraitC::conflict as protected noConflict;
+    }
+
+    /**
+     * @In
+     */
+    private $intermediate;
 }


### PR DESCRIPTION
Fix for issue #81 

Use statements are now also imported for properties
and methods from traits in traits. Conflict resolution
and aliases are respected.

For backwards compatibility reasons the use statements
from the declaring class are still merged. PHP itself 
does not show this behaviour regarding to imported types
in traits.

For the methods in traits I use `\ReflectionMethod::getFileName()`
and then parse the file since this is the only way I can think of to
get the right declaration location in the face of imported traits using
conflict resolution. This same method is also possible for the
properties if you would prefer it.
