### PR TITLE
skip cache writes.

### DIFF
--- a/lib/Doctrine/Common/Annotations/CachedReader.php
+++ b/lib/Doctrine/Common/Annotations/CachedReader.php
@@ -185,8 +185,12 @@ final class CachedReader implements Reader
      */
     private function fetchFromCache($cacheKey, ReflectionClass $class)
     {
+        if ($this->debug) {
+            return false;
+        }
+
         if (($data = $this->cache->fetch($cacheKey)) !== false) {
-            if (!$this->debug || $this->isCacheFresh($cacheKey, $class)) {
+            if ($this->isCacheFresh($cacheKey, $class)) {
                 return $data;
             }
         }
@@ -204,6 +208,11 @@ final class CachedReader implements Reader
      */
     private function saveToCache($cacheKey, $value)
     {
+        // Debug won't use the cache - save io and skip all writes.
+        if ($this->debug) {
+            return;
+        }
+
         $this->cache->save($cacheKey, $value);
         if ($this->debug) {
             $this->cache->save('[C]'.$cacheKey, time());

--- a/tests/Doctrine/Tests/Common/Annotations/CachedReaderTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/CachedReaderTest.php
@@ -103,7 +103,7 @@ class CachedReaderTest extends AbstractReaderTest
             ->with($this->equalTo('[C]'.$cacheKey))
         ;
 
-        $reader = new CachedReader(new AnnotationReader(), $cache, true);
+        $reader = new CachedReader(new AnnotationReader(), $cache, false);
         $route = new Route();
         $route->pattern = '/someprefix';
 


### PR DESCRIPTION
Cache files aren't used when debug is true. To save IO, this PR skips the write function. It also skips the $this->cache->fetch() execution.

If the cache files aren't being read from, I can't think of a reason why the files should be written.