### PR TITLE
Timestamp returned for trait last modification times in the cached reader should be an integer, is an array

### DIFF
--- a/lib/Doctrine/Common/Annotations/CachedReader.php
+++ b/lib/Doctrine/Common/Annotations/CachedReader.php
@@ -246,13 +246,17 @@ final class CachedReader implements Reader
         ));
     }
 
+    /**
+     * @param ReflectionClass $reflectionTrait
+     * @return int
+     */
     private function getTraitLastModificationTimes(ReflectionClass $reflectionTrait)
     {
         $fileName = $reflectionTrait->getFileName();
 
-        return array_merge(
+        return max(array_merge(
             [$fileName ? filemtime($fileName) : 0],
             array_map([$this, 'getTraitLastModificationTimes'], $reflectionTrait->getTraits())
-        );
+        ));
     }
 }

--- a/lib/Doctrine/Common/Annotations/CachedReader.php
+++ b/lib/Doctrine/Common/Annotations/CachedReader.php
@@ -240,7 +240,7 @@ final class CachedReader implements Reader
 
         return max(array_merge(
             [$filename ? filemtime($filename) : 0],
-            array_map([$this, 'getTraitLastModificationTimes'], $class->getTraits()),
+            array_map([$this, 'getTraitLastModificationTime'], $class->getTraits()),
             array_map([$this, 'getLastModification'], $class->getInterfaces()),
             $parent ? [$this->getLastModification($parent)] : []
         ));
@@ -250,13 +250,13 @@ final class CachedReader implements Reader
      * @param ReflectionClass $reflectionTrait
      * @return int
      */
-    private function getTraitLastModificationTimes(ReflectionClass $reflectionTrait)
+    private function getTraitLastModificationTime(ReflectionClass $reflectionTrait)
     {
         $fileName = $reflectionTrait->getFileName();
 
         return max(array_merge(
             [$fileName ? filemtime($fileName) : 0],
-            array_map([$this, 'getTraitLastModificationTimes'], $reflectionTrait->getTraits())
+            array_map([$this, 'getTraitLastModificationTime'], $reflectionTrait->getTraits())
         ));
     }
 }


### PR DESCRIPTION
This PR fixes an issue where the cache is constantly being written - wasting IO.

After looking into this further, I found that the problem I'm having with excessive IO is because getLastModification is merging the timestamps incorrectly.

The result of the following can't be merged:

```php
dump(array_merge(
    [$filename ? filemtime($filename) : 0],
    array_map([$this, 'getTraitLastModificationTimes'], $class->getTraits()),
    array_map([$this, 'getLastModification'], $class->getInterfaces()),
    $parent ? [$this->getLastModification($parent)] : []
));
```

![screen shot 2016-11-14 at 11 29 03 am](https://cloud.githubusercontent.com/assets/869933/20250868/659c99c2-aa5f-11e6-85ee-e7f8b63e7d1d.png)

The result of this is that it can't work out the max() of the traits.

To resolve this, I updated getTraitLastModificationTimes to always return the max timestamp.

Using this PR in favour of another change I made: https://github.com/doctrine/annotations/pull/104

