### PR TITLE
Missing annotations with the latest composer version

### DIFF
--- a/lib/Doctrine/Common/Annotations/DocParser.php
+++ b/lib/Doctrine/Common/Annotations/DocParser.php
@@ -728,6 +728,8 @@ final class DocParser
             }
         }
 
+        $name = ltrim($name,'\\');
+
         if ( ! $this->classExists($name)) {
             throw AnnotationException::semanticalError(sprintf('The annotation "@%s" in %s does not exist, or could not be auto-loaded.', $name, $this->context));
         }

--- a/tests/Doctrine/Tests/Common/Annotations/AnnotationReaderTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/AnnotationReaderTest.php
@@ -2,8 +2,11 @@
 
 namespace Doctrine\Tests\Common\Annotations;
 
+use Doctrine\Common\Annotations\AnnotationException;
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Annotations\DocParser;
+use Doctrine\Tests\Common\Annotations\Fixtures\Annotation\SingleUseAnnotation;
+use Doctrine\Tests\Common\Annotations\Fixtures\ClassWithFullPathUseStatement;
 use Doctrine\Tests\Common\Annotations\Fixtures\IgnoredNamespaces\AnnotatedAtClassLevel;
 use Doctrine\Tests\Common\Annotations\Fixtures\IgnoredNamespaces\AnnotatedAtMethodLevel;
 use Doctrine\Tests\Common\Annotations\Fixtures\IgnoredNamespaces\AnnotatedAtPropertyLevel;
@@ -107,5 +110,19 @@ class AnnotationReaderTest extends AbstractReaderTest
         $reader::addGlobalIgnoredNamespace('SomePropertyAnnotationNamespace');
 
         self::assertEmpty($reader->getPropertyAnnotations($ref->getProperty('property')));
+    }
+
+    public function testClassWithFullPathUseStatement()
+    {
+        if (class_exists(SingleUseAnnotation::class, false)) {
+            throw new \LogicException('The SingleUseAnnotation must not be used in other tests for this test to be useful');
+        }
+
+        $reader = $this->getReader();
+        $ref = new \ReflectionClass(ClassWithFullPathUseStatement::class);
+
+        $annotations = $reader->getClassAnnotations($ref);
+
+        self::assertInstanceOf(SingleUseAnnotation::class,$annotations[0]);
     }
 }

--- a/tests/Doctrine/Tests/Common/Annotations/Fixtures/Annotation/SingleUseAnnotation.php
+++ b/tests/Doctrine/Tests/Common/Annotations/Fixtures/Annotation/SingleUseAnnotation.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Doctrine\Tests\Common\Annotations\Fixtures\Annotation;
+
+/**
+ * @Annotation
+ */
+class SingleUseAnnotation
+{
+
+}

--- a/tests/Doctrine/Tests/Common/Annotations/Fixtures/ClassWithFullPathUseStatement.php
+++ b/tests/Doctrine/Tests/Common/Annotations/Fixtures/ClassWithFullPathUseStatement.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Doctrine\Tests\Common\Annotations\Fixtures;
+
+/**
+ * The leading \ is intentional to ensure that code using
+ * this use statement format works see issue #115/PR #120
+ */
+use \Doctrine\Tests\Common\Annotations\Fixtures\Annotation as Annotations;
+
+/**
+ * @Annotations\SingleUseAnnotation
+ */
+class ClassWithFullPathUseStatement
+{
+
+}


### PR DESCRIPTION
This PR demonstrates the issue with #115 as well as a potential fix.

There's one oddity here however, I can only cause the failure if I *only* run that one test. This is why the test I added has a '@group gnat' annotation.

When I run 
```
phpunit --group gnat
```
Without my fix in place in DocParser it fails, running all tests for some reason doesn't fail. I'm not sure why. I also realize that really I should have a test against DocParser instead, since that is where the issue lies. However this was a proof of concept of the issue. If you comment out my changes in DocParser, the error we're getting in symfony based projects happens.