### PR TITLE
Add `@required` to global ignore list

### DIFF
--- a/lib/Doctrine/Common/Annotations/AnnotationReader.php
+++ b/lib/Doctrine/Common/Annotations/AnnotationReader.php
@@ -56,7 +56,7 @@ class AnnotationReader implements Reader
         // Annotation tags
         'Annotation' => true, 'Attribute' => true, 'Attributes' => true,
         /* Can we enable this? 'Enum' => true, */
-        'Required' => true,
+        'Required' => true, 'required' => true,
         'Target' => true,
         // Widely used tags (but not existent in phpdoc)
         'fix' => true , 'fixme' => true,


### PR DESCRIPTION
Symfony 3.3 is going to make use of the `@required` annotation, but in lower case form, to make it visually visible that this is a global annotation in the same group as `@deprecated` or `@return`, etc. - *vs* local annotations that map to classes, thus usually start with an uppercase.