### PR TITLE
Missing throws annotation in AnnotationReader

### DIFF
--- a/lib/Doctrine/Common/Annotations/AnnotationReader.php
+++ b/lib/Doctrine/Common/Annotations/AnnotationReader.php
@@ -172,6 +172,8 @@ class AnnotationReader implements Reader
      * Initializes a new AnnotationReader.
      *
      * @param DocParser $parser
+     *
+     * @throws AnnotationException
      */
     public function __construct(DocParser $parser = null)
     {


### PR DESCRIPTION
I've just added a missing `@throws` annotation to the constructor of AnnotationReader.

I'm not sure if this wasn't added before, because it only depends on the PHP installation and configuration and makes this information less interesting for developers during their development and maybe spoils their IDE's static code checks.

If that was the reason, you can close this PR.