### PR TITLE
Prevent the same loader from being registered twice

### DIFF
--- a/lib/Doctrine/Common/Annotations/AnnotationRegistry.php
+++ b/lib/Doctrine/Common/Annotations/AnnotationRegistry.php
@@ -110,7 +110,9 @@ final class AnnotationRegistry
         if (!is_callable($callable)) {
             throw new \InvalidArgumentException("A callable is expected in AnnotationRegistry::registerLoader().");
         }
-        self::$loaders[] = $callable;
+        if (!in_array($callable, self::$loaders)) {
+            self::$loaders[] = $callable;
+        }
     }
 
     /**

--- a/lib/Doctrine/Common/Annotations/AnnotationRegistry.php
+++ b/lib/Doctrine/Common/Annotations/AnnotationRegistry.php
@@ -44,12 +44,28 @@ final class AnnotationRegistry
     static private $loaders = array();
 
     /**
+     * An array of loaded classes
+     *
+     * @var array
+     */
+    static private $loaded = array();
+
+    /**
+     * An array of classes which cannot be found
+     *
+     * @var array
+     */
+    static private $unloadable = array();
+
+    /**
      * @return void
      */
     static public function reset()
     {
         self::$autoloadNamespaces = array();
         self::$loaders = array();
+        self::$loaded = array();
+        self::$unloadable = array();
     }
 
     /**
@@ -110,9 +126,10 @@ final class AnnotationRegistry
         if (!is_callable($callable)) {
             throw new \InvalidArgumentException("A callable is expected in AnnotationRegistry::registerLoader().");
         }
-        if (!in_array($callable, self::$loaders)) {
-            self::$loaders[] = $callable;
-        }
+        // Reset our static cache now that we have a new loader to work with
+        self::$loaded = array();
+        self::$unloadable = array();
+        self::$loaders[] = $callable;
     }
 
     /**
@@ -124,18 +141,26 @@ final class AnnotationRegistry
      */
     static public function loadAnnotationClass($class)
     {
+        if (isset(self::$loaded[$class])) {
+            return true;
+        }
+        if (isset(self::$unloadable[$class])) {
+            return false;
+        }
         foreach (self::$autoloadNamespaces AS $namespace => $dirs) {
             if (strpos($class, $namespace) === 0) {
                 $file = str_replace("\\", DIRECTORY_SEPARATOR, $class) . ".php";
                 if ($dirs === null) {
                     if ($path = stream_resolve_include_path($file)) {
                         require $path;
+                        self::$loaded[$class] = true;
                         return true;
                     }
                 } else {
                     foreach((array)$dirs AS $dir) {
                         if (is_file($dir . DIRECTORY_SEPARATOR . $file)) {
                             require $dir . DIRECTORY_SEPARATOR . $file;
+                            self::$loaded[$class] = true;
                             return true;
                         }
                     }
@@ -145,9 +170,11 @@ final class AnnotationRegistry
 
         foreach (self::$loaders AS $loader) {
             if (call_user_func($loader, $class) === true) {
+                self::$loaded[$class] = true;
                 return true;
             }
         }
+        self::$unloadable[$class] = true;
         return false;
     }
 }

--- a/tests/Doctrine/Tests/Common/Annotations/AnnotationRegistryTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/AnnotationRegistryTest.php
@@ -65,4 +65,12 @@ class AnnotationRegistryTest extends \PHPUnit_Framework_TestCase
 
         return $reflection->getValue();
     }
+
+    public function testRegisterLoaderTwiceOnlySavedOnce()
+    {
+        AnnotationRegistry::registerLoader('class_exists');
+        AnnotationRegistry::registerLoader('class_exists');
+
+        self::assertEquals(['class_exists'], $this->getStaticField($this->class, 'loaders'));
+    }
 }


### PR DESCRIPTION
Registering an expensive loader like `class_exists` twice doubles the
number of calls to the callable - this prevents that from happening.

This PR is a specific defensive response to `class_exists` now being added by both:
https://github.com/symfony/symfony/blob/master/src/Symfony/Bundle/FrameworkBundle/Resources/config/annotations.xml#L17
and
https://github.com/symfony/phpunit-bridge/blob/master/bootstrap.php#L24

Which caused `class_exists` to be called 133K more times in one example test.

Edit: This is actually much worse than I originally thought. Because many of my functional tests boot kernels and the Registry is static by the middle of my test run there are 25+ `class_exists` registered and everything grinds to a halt.