### PR TITLE
#135 optimise multiple class load attempts in `AnnotationRegistry`

### DIFF
--- a/lib/Doctrine/Common/Annotations/AnnotationRegistry.php
+++ b/lib/Doctrine/Common/Annotations/AnnotationRegistry.php
@@ -112,6 +112,10 @@ final class AnnotationRegistry
      * @return void
      *
      * @throws \InvalidArgumentException
+     *
+     * @deprecated this method is deprecated and will be removed in doctrine/annotations 2.0
+     *             autoloading should be deferred to the globally registered autoloader by then. For now,
+     *             use @example AnnotationRegistry::registerLoader('class_exists')
      */
     public static function registerLoader(callable $callable)
     {

--- a/lib/Doctrine/Common/Annotations/AnnotationRegistry.php
+++ b/lib/Doctrine/Common/Annotations/AnnotationRegistry.php
@@ -63,11 +63,11 @@ final class AnnotationRegistry
     /**
      * Registers file.
      *
-     * @param string $file
-     *
-     * @return void
+     * @deprecated this method is deprecated and will be removed in doctrine/annotations 2.0
+     *             autoloading should be deferred to the globally registered autoloader by then. For now,
+     *             use @example AnnotationRegistry::registerLoader('class_exists')
      */
-    public static function registerFile($file)
+    public static function registerFile(string $file) : void
     {
         require_once $file;
     }
@@ -80,9 +80,11 @@ final class AnnotationRegistry
      * @param string            $namespace
      * @param string|array|null $dirs
      *
-     * @return void
+     * @deprecated this method is deprecated and will be removed in doctrine/annotations 2.0
+     *             autoloading should be deferred to the globally registered autoloader by then. For now,
+     *             use @example AnnotationRegistry::registerLoader('class_exists')
      */
-    public static function registerAutoloadNamespace($namespace, $dirs = null)
+    public static function registerAutoloadNamespace(string $namespace, $dirs = null) : void
     {
         self::$autoloadNamespaces[$namespace] = $dirs;
     }
@@ -92,11 +94,13 @@ final class AnnotationRegistry
      *
      * Loading of this namespaces will be done with a PSR-0 namespace loading algorithm.
      *
-     * @param array $namespaces
+     * @param string[][]|string[]|null[] $namespaces indexed by namespace name
      *
-     * @return void
+     * @deprecated this method is deprecated and will be removed in doctrine/annotations 2.0
+     *             autoloading should be deferred to the globally registered autoloader by then. For now,
+     *             use @example AnnotationRegistry::registerLoader('class_exists')
      */
-    public static function registerAutoloadNamespaces(array $namespaces)
+    public static function registerAutoloadNamespaces(array $namespaces) : void
     {
         self::$autoloadNamespaces = \array_merge(self::$autoloadNamespaces, $namespaces);
     }
@@ -107,17 +111,11 @@ final class AnnotationRegistry
      * NOTE: These class loaders HAVE to be silent when a class was not found!
      * IMPORTANT: Loaders have to return true if they loaded a class that could contain the searched annotation class.
      *
-     * @param callable $callable
-     *
-     * @return void
-     *
-     * @throws \InvalidArgumentException
-     *
      * @deprecated this method is deprecated and will be removed in doctrine/annotations 2.0
      *             autoloading should be deferred to the globally registered autoloader by then. For now,
      *             use @example AnnotationRegistry::registerLoader('class_exists')
      */
-    public static function registerLoader(callable $callable)
+    public static function registerLoader(callable $callable) : void
     {
         // Reset our static cache now that we have a new loader to work with
         self::$failedToAutoload   = [];
@@ -140,6 +138,7 @@ final class AnnotationRegistry
         foreach (self::$autoloadNamespaces AS $namespace => $dirs) {
             if (\strpos($class, $namespace) === 0) {
                 $file = \str_replace('\\', \DIRECTORY_SEPARATOR, $class) . '.php';
+
                 if ($dirs === null) {
                     if ($path = stream_resolve_include_path($file)) {
                         require $path;

--- a/lib/Doctrine/Common/Annotations/AnnotationRegistry.php
+++ b/lib/Doctrine/Common/Annotations/AnnotationRegistry.php
@@ -141,9 +141,10 @@ final class AnnotationRegistry
      */
     static public function loadAnnotationClass($class)
     {
-        if (isset(self::$successfullyLoaded[$class])) {
+        if (\class_exists($class, false)) {
             return true;
         }
+
         if (isset(self::$failedToAutoload[$class])) {
             return false;
         }

--- a/lib/Doctrine/Common/Annotations/AnnotationRegistry.php
+++ b/lib/Doctrine/Common/Annotations/AnnotationRegistry.php
@@ -110,7 +110,9 @@ final class AnnotationRegistry
         if (!is_callable($callable)) {
             throw new \InvalidArgumentException("A callable is expected in AnnotationRegistry::registerLoader().");
         }
-        self::$loaders[] = $callable;
+        if (!in_array($callable, self::$loaders)) {
+            self::$loaders[] = $callable;
+        }
     }
 
     /**

--- a/lib/Doctrine/Common/Annotations/AnnotationRegistry.php
+++ b/lib/Doctrine/Common/Annotations/AnnotationRegistry.php
@@ -46,7 +46,7 @@ final class AnnotationRegistry
     /**
      * An array of classes which cannot be found
      *
-     * @var array
+     * @var null[] indexed by class name
      */
     static private $failedToAutoload = array();
 
@@ -133,9 +133,10 @@ final class AnnotationRegistry
             return true;
         }
 
-        if (isset(self::$failedToAutoload[$class])) {
+        if (\array_key_exists($class, self::$failedToAutoload[$class])) {
             return false;
         }
+
         foreach (self::$autoloadNamespaces AS $namespace => $dirs) {
             if (strpos($class, $namespace) === 0) {
                 $file = str_replace("\\", DIRECTORY_SEPARATOR, $class) . ".php";
@@ -160,7 +161,9 @@ final class AnnotationRegistry
                 return true;
             }
         }
-        self::$failedToAutoload[$class] = true;
+
+        self::$failedToAutoload[$class] = null;
+
         return false;
     }
 }

--- a/lib/Doctrine/Common/Annotations/AnnotationRegistry.php
+++ b/lib/Doctrine/Common/Annotations/AnnotationRegistry.php
@@ -34,30 +34,30 @@ final class AnnotationRegistry
      *
      * @var array
      */
-    static private $autoloadNamespaces = array();
+    static private $autoloadNamespaces = [];
 
     /**
      * A map of autoloader callables.
      *
      * @var array
      */
-    static private $loaders = array();
+    static private $loaders = [];
 
     /**
      * An array of classes which cannot be found
      *
      * @var null[] indexed by class name
      */
-    static private $failedToAutoload = array();
+    static private $failedToAutoload = [];
 
     /**
      * @return void
      */
-    static public function reset()
+    public static function reset()
     {
-        self::$autoloadNamespaces = array();
-        self::$loaders            = array();
-        self::$failedToAutoload   = array();
+        self::$autoloadNamespaces = [];
+        self::$loaders            = [];
+        self::$failedToAutoload   = [];
     }
 
     /**
@@ -67,7 +67,7 @@ final class AnnotationRegistry
      *
      * @return void
      */
-    static public function registerFile($file)
+    public static function registerFile($file)
     {
         require_once $file;
     }
@@ -82,7 +82,7 @@ final class AnnotationRegistry
      *
      * @return void
      */
-    static public function registerAutoloadNamespace($namespace, $dirs = null)
+    public static function registerAutoloadNamespace($namespace, $dirs = null)
     {
         self::$autoloadNamespaces[$namespace] = $dirs;
     }
@@ -96,9 +96,9 @@ final class AnnotationRegistry
      *
      * @return void
      */
-    static public function registerAutoloadNamespaces(array $namespaces)
+    public static function registerAutoloadNamespaces(array $namespaces)
     {
-        self::$autoloadNamespaces = array_merge(self::$autoloadNamespaces, $namespaces);
+        self::$autoloadNamespaces = \array_merge(self::$autoloadNamespaces, $namespaces);
     }
 
     /**
@@ -113,33 +113,29 @@ final class AnnotationRegistry
      *
      * @throws \InvalidArgumentException
      */
-    static public function registerLoader(callable $callable)
+    public static function registerLoader(callable $callable)
     {
         // Reset our static cache now that we have a new loader to work with
-        self::$failedToAutoload   = array();
+        self::$failedToAutoload   = [];
         self::$loaders[]          = $callable;
     }
 
     /**
      * Autoloads an annotation class silently.
-     *
-     * @param string $class
-     *
-     * @return boolean
      */
-    static public function loadAnnotationClass($class)
+    public static function loadAnnotationClass(string $class) : bool
     {
         if (\class_exists($class, false)) {
             return true;
         }
 
-        if (\array_key_exists($class, self::$failedToAutoload[$class])) {
+        if (\array_key_exists($class, self::$failedToAutoload)) {
             return false;
         }
 
         foreach (self::$autoloadNamespaces AS $namespace => $dirs) {
-            if (strpos($class, $namespace) === 0) {
-                $file = str_replace("\\", DIRECTORY_SEPARATOR, $class) . ".php";
+            if (\strpos($class, $namespace) === 0) {
+                $file = \str_replace('\\', \DIRECTORY_SEPARATOR, $class) . '.php';
                 if ($dirs === null) {
                     if ($path = stream_resolve_include_path($file)) {
                         require $path;
@@ -147,8 +143,8 @@ final class AnnotationRegistry
                     }
                 } else {
                     foreach((array)$dirs AS $dir) {
-                        if (is_file($dir . DIRECTORY_SEPARATOR . $file)) {
-                            require $dir . DIRECTORY_SEPARATOR . $file;
+                        if (is_file($dir . \DIRECTORY_SEPARATOR . $file)) {
+                            require $dir . \DIRECTORY_SEPARATOR . $file;
                             return true;
                         }
                     }
@@ -157,7 +153,7 @@ final class AnnotationRegistry
         }
 
         foreach (self::$loaders AS $loader) {
-            if (call_user_func($loader, $class) === true) {
+            if ($loader($class) === true) {
                 return true;
             }
         }

--- a/lib/Doctrine/Common/Annotations/AnnotationRegistry.php
+++ b/lib/Doctrine/Common/Annotations/AnnotationRegistry.php
@@ -44,13 +44,6 @@ final class AnnotationRegistry
     static private $loaders = array();
 
     /**
-     * An array of loaded classes
-     *
-     * @var array
-     */
-    static private $successfullyLoaded = array();
-
-    /**
      * An array of classes which cannot be found
      *
      * @var array
@@ -64,7 +57,6 @@ final class AnnotationRegistry
     {
         self::$autoloadNamespaces = array();
         self::$loaders            = array();
-        self::$successfullyLoaded = array();
         self::$failedToAutoload   = array();
     }
 
@@ -127,7 +119,6 @@ final class AnnotationRegistry
             throw new \InvalidArgumentException("A callable is expected in AnnotationRegistry::registerLoader().");
         }
         // Reset our static cache now that we have a new loader to work with
-        self::$successfullyLoaded = array();
         self::$failedToAutoload   = array();
         self::$loaders[]          = $callable;
     }
@@ -154,14 +145,12 @@ final class AnnotationRegistry
                 if ($dirs === null) {
                     if ($path = stream_resolve_include_path($file)) {
                         require $path;
-                        self::$successfullyLoaded[$class] = true;
                         return true;
                     }
                 } else {
                     foreach((array)$dirs AS $dir) {
                         if (is_file($dir . DIRECTORY_SEPARATOR . $file)) {
                             require $dir . DIRECTORY_SEPARATOR . $file;
-                            self::$successfullyLoaded[$class] = true;
                             return true;
                         }
                     }
@@ -171,7 +160,6 @@ final class AnnotationRegistry
 
         foreach (self::$loaders AS $loader) {
             if (call_user_func($loader, $class) === true) {
-                self::$successfullyLoaded[$class] = true;
                 return true;
             }
         }

--- a/lib/Doctrine/Common/Annotations/AnnotationRegistry.php
+++ b/lib/Doctrine/Common/Annotations/AnnotationRegistry.php
@@ -29,14 +29,14 @@ final class AnnotationRegistry
      *
      * This autoloading mechanism does not utilize the PHP autoloading but implements autoloading on its own.
      *
-     * @var array
+     * @var string[][]|string[]|null[]
      */
     static private $autoloadNamespaces = [];
 
     /**
      * A map of autoloader callables.
      *
-     * @var array
+     * @var callable[]
      */
     static private $loaders = [];
 
@@ -47,10 +47,7 @@ final class AnnotationRegistry
      */
     static private $failedToAutoload = [];
 
-    /**
-     * @return void
-     */
-    public static function reset()
+    public static function reset() : void
     {
         self::$autoloadNamespaces = [];
         self::$loaders            = [];

--- a/lib/Doctrine/Common/Annotations/AnnotationRegistry.php
+++ b/lib/Doctrine/Common/Annotations/AnnotationRegistry.php
@@ -19,9 +19,6 @@
 
 namespace Doctrine\Common\Annotations;
 
-/**
- * AnnotationRegistry.
- */
 final class AnnotationRegistry
 {
     /**

--- a/lib/Doctrine/Common/Annotations/AnnotationRegistry.php
+++ b/lib/Doctrine/Common/Annotations/AnnotationRegistry.php
@@ -44,12 +44,28 @@ final class AnnotationRegistry
     static private $loaders = array();
 
     /**
+     * An array of loaded classes
+     *
+     * @var array
+     */
+    static private $loaded = array();
+
+    /**
+     * An array of classes which cannot be found
+     *
+     * @var array
+     */
+    static private $unloadable = array();
+
+    /**
      * @return void
      */
     static public function reset()
     {
         self::$autoloadNamespaces = array();
         self::$loaders = array();
+        self::$loaded = array();
+        self::$unloadable = array();
     }
 
     /**
@@ -110,9 +126,10 @@ final class AnnotationRegistry
         if (!is_callable($callable)) {
             throw new \InvalidArgumentException("A callable is expected in AnnotationRegistry::registerLoader().");
         }
-        if (!in_array($callable, self::$loaders)) {
-            self::$loaders[] = $callable;
-        }
+        // Reset our static cache now that we have a new loader to work with
+        self::$loaded = array();
+        self::$unloadable = array();
+        self::$loaders[] = $callable;
     }
 
     /**
@@ -124,18 +141,26 @@ final class AnnotationRegistry
      */
     static public function loadAnnotationClass($class)
     {
+        if (isset(self::$loaded[$class])) {
+            return true;
+        }
+        if (isset(self::$unloadable[$class])) {
+            return false;
+        }
         foreach (self::$autoloadNamespaces AS $namespace => $dirs) {
             if (strpos($class, $namespace) === 0) {
                 $file = str_replace("\\", DIRECTORY_SEPARATOR, $class) . ".php";
                 if ($dirs === null) {
                     if ($path = stream_resolve_include_path($file)) {
                         require $path;
+                        self::$loaded[$class] = true;
                         return true;
                     }
                 } else {
                     foreach((array)$dirs AS $dir) {
                         if (is_file($dir . DIRECTORY_SEPARATOR . $file)) {
                             require $dir . DIRECTORY_SEPARATOR . $file;
+                            self::$loaded[$class] = true;
                             return true;
                         }
                     }
@@ -145,9 +170,11 @@ final class AnnotationRegistry
 
         foreach (self::$loaders AS $loader) {
             if (call_user_func($loader, $class) === true) {
+                self::$loaded[$class] = true;
                 return true;
             }
         }
+        self::$unloadable[$class] = true;
         return false;
     }
 }

--- a/lib/Doctrine/Common/Annotations/AnnotationRegistry.php
+++ b/lib/Doctrine/Common/Annotations/AnnotationRegistry.php
@@ -113,11 +113,8 @@ final class AnnotationRegistry
      *
      * @throws \InvalidArgumentException
      */
-    static public function registerLoader($callable)
+    static public function registerLoader(callable $callable)
     {
-        if (!is_callable($callable)) {
-            throw new \InvalidArgumentException("A callable is expected in AnnotationRegistry::registerLoader().");
-        }
         // Reset our static cache now that we have a new loader to work with
         self::$failedToAutoload   = array();
         self::$loaders[]          = $callable;

--- a/tests/Doctrine/Tests/Common/Annotations/AnnotationRegistryTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/AnnotationRegistryTest.php
@@ -65,4 +65,12 @@ class AnnotationRegistryTest extends \PHPUnit_Framework_TestCase
 
         return $reflection->getValue();
     }
+
+    public function testRegisterLoaderTwiceOnlySavedOnce()
+    {
+        AnnotationRegistry::registerLoader('class_exists');
+        AnnotationRegistry::registerLoader('class_exists');
+
+        self::assertEquals(['class_exists'], $this->getStaticField($this->class, 'loaders'));
+    }
 }

--- a/tests/Doctrine/Tests/Common/Annotations/AnnotationRegistryTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/AnnotationRegistryTest.php
@@ -40,13 +40,12 @@ class AnnotationRegistryTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @runInSeparateProcess
-     *
-     * @expectedException   \InvalidArgumentException
-     * @expectedExceptionMessage A callable is expected in AnnotationRegistry::registerLoader().
      */
     public function testRegisterLoaderNoCallable()
     {
-        AnnotationRegistry::registerLoader('test');
+        $this->expectException(\TypeError::class);
+
+        AnnotationRegistry::registerLoader('test' . random_int(10, 10000));
     }
 
     protected function setStaticField($class, $field, $value)


### PR DESCRIPTION
This PR includes #135 as well as a number of fixes around the `AnnotationRegistry` class (which is mostly a horror show from the pre-composer era).