### PR TITLE
#141 `::class` notations with FQCN notation and leading `\` causes `\` to be part of the produced string value

### DIFF
--- a/lib/Doctrine/Common/Annotations/DocParser.php
+++ b/lib/Doctrine/Common/Annotations/DocParser.php
@@ -968,10 +968,14 @@ final class DocParser
             }
         }
 
-        // checks if identifier ends with ::class, \strlen('::class') === 7
-        $classPos = stripos($identifier, '::class');
-        if ($classPos === strlen($identifier) - 7) {
-            return substr($identifier, 0, $classPos);
+        /**
+         * Checks if identifier ends with ::class and remove the leading backslash if it exists.
+         */
+        if ($this->identifierEndsWithClassConstant($identifier) && ! $this->identifierStartsWithBackslash($identifier)) {
+            return substr($identifier, 0, $this->getClassConstantPositionInIdentifier($identifier));
+        }
+        if ($this->identifierEndsWithClassConstant($identifier) && $this->identifierStartsWithBackslash($identifier)) {
+            return substr($identifier, 1, $this->getClassConstantPositionInIdentifier($identifier) - 1);
         }
 
         if (!defined($identifier)) {
@@ -979,6 +983,24 @@ final class DocParser
         }
 
         return constant($identifier);
+    }
+
+    private function identifierStartsWithBackslash(string $identifier) : bool
+    {
+        return '\\' === $identifier[0];
+    }
+
+    private function identifierEndsWithClassConstant(string $identifier) : bool
+    {
+        return $this->getClassConstantPositionInIdentifier($identifier) === strlen($identifier) - strlen('::class');
+    }
+
+    /**
+     * @return int|false
+     */
+    private function getClassConstantPositionInIdentifier(string $identifier)
+    {
+        return stripos($identifier, '::class');
     }
 
     /**

--- a/tests/Doctrine/Tests/Common/Annotations/Ticket/DCOM141Test.php
+++ b/tests/Doctrine/Tests/Common/Annotations/Ticket/DCOM141Test.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Doctrine\Tests\Common\Annotations\Ticket;
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+/**
+ * @group
+ */
+class DCOM141Test extends TestCase
+{
+    public function testAnnotationPrefixed()
+    {
+        $class = new ReflectionClass(DCOM141ConsumerPrefixed::class);
+        $reader = new AnnotationReader();
+        $annots = $reader->getClassAnnotations($class);
+
+        self::assertCount(1, $annots);
+        self::assertInstanceOf(DCOM141Annotation::class, $annots[0]);
+        self::assertEquals('SimpleXMLElement', $annots[0]->classPath);
+    }
+
+    public function testAnnotationNotPrefixed()
+    {
+        $class = new \ReflectionClass(DCOM141ConsumerNotPrefixed::class);
+        $reader = new AnnotationReader();
+        $annots = $reader->getClassAnnotations($class);
+
+        self::assertCount(1, $annots);
+        self::assertInstanceOf(DCOM141Annotation::class, $annots[0]);
+        self::assertEquals('SimpleXMLElement', $annots[0]->classPath);
+    }
+
+}
+
+/**
+ * @Annotation
+ */
+class DCOM141Annotation
+{
+    public $classPath;
+}
+
+/**
+ * @DCOM141Annotation(\SimpleXMLElement::class)
+ */
+class DCOM141ConsumerPrefixed
+{
+
+}
+
+/**
+ * @DCOM141Annotation(SimpleXMLElement::class)
+ */
+class DCOM141ConsumerNotPrefixed
+{
+
+}


### PR DESCRIPTION
When there is a leading backslash in front of a class name
as annotation value, the leading backslash gets removed.

Fixes #141