### PR TITLE
Ignoring @experimental annotation used by Symfony 3.3 CacheAdapter

### DIFF
--- a/lib/Doctrine/Common/Annotations/AnnotationReader.php
+++ b/lib/Doctrine/Common/Annotations/AnnotationReader.php
@@ -100,6 +100,8 @@ class AnnotationReader implements Reader
         'package_version' => true,
         // PlantUML
         'startuml' => true, 'enduml' => true,
+        // Symfony 3.3 Cache Adapter
+        'experimental' => true
     );
 
     /**


### PR DESCRIPTION
Fix for #146 