### PR TITLE
Ignoring @suppress annotation used by Phan

### DIFF
--- a/lib/Doctrine/Common/Annotations/AnnotationReader.php
+++ b/lib/Doctrine/Common/Annotations/AnnotationReader.php
@@ -101,7 +101,9 @@ class AnnotationReader implements Reader
         // PlantUML
         'startuml' => true, 'enduml' => true,
         // Symfony 3.3 Cache Adapter
-        'experimental' => true
+        'experimental' => true,
+        // Phan suppress error
+        'suppress' => true
     );
 
     /**


### PR DESCRIPTION
Phan used `@suppress`, which currently throws an exception when used. See https://github.com/phan/phan/wiki/Annotating-Your-Source-Code#suppress. 