### PR TITLE
Ingore PHPstorm's @mixin annotation

### DIFF
--- a/lib/Doctrine/Common/Annotations/AnnotationReader.php
+++ b/lib/Doctrine/Common/Annotations/AnnotationReader.php
@@ -96,6 +96,7 @@ class AnnotationReader implements Reader
         'SuppressWarnings' => true,
         // PHPStorm
         'noinspection' => true,
+        'mixin' => true,
         // PEAR
         'package_version' => true,
         // PlantUML


### PR DESCRIPTION
PHPstorm supports a `@mixin` annotation, which is currently not ignored by the AnnotationReader.

Jetbrains issue ref: https://youtrack.jetbrains.com/issue/WI-1730