### PR TITLE
Add registerLoaderIfNotExists to AnnotationRegistry

### DIFF
--- a/lib/Doctrine/Common/Annotations/AnnotationRegistry.php
+++ b/lib/Doctrine/Common/Annotations/AnnotationRegistry.php
@@ -117,6 +117,18 @@ final class AnnotationRegistry
     }
 
     /**
+     * Registers an autoloading callable for annotations, if it is not already registered
+     *
+     * @deprecated this method is deprecated and will be removed in doctrine/annotations 2.0
+     */
+    public static function registerUniqueLoader(callable $callable) : void
+    {
+        if ( ! in_array($callable, self::$loaders, true) ) {
+            self::registerLoader($callable);
+        }
+    }
+
+    /**
      * Autoloads an annotation class silently.
      */
     public static function loadAnnotationClass(string $class) : bool

--- a/tests/Doctrine/Tests/Common/Annotations/AnnotationRegistryTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/AnnotationRegistryTest.php
@@ -168,4 +168,19 @@ class AnnotationRegistryTest extends TestCase
 
         self::assertSame(2, $failures);
     }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testRegisterLoaderIfNotExistsOnlyRegisteresSameLoaderOnce() : void
+    {
+        $className = 'autoloadedClassThatDoesNotExist';
+        AnnotationRegistry::reset();
+        $autoLoader = self::createPartialMock(\stdClass::class, ['__invoke']);
+        $autoLoader->expects($this->once())->method('__invoke');
+        AnnotationRegistry::registerUniqueLoader($autoLoader);
+        AnnotationRegistry::registerUniqueLoader($autoLoader);
+        AnnotationRegistry::loadAnnotationClass($className);
+        AnnotationRegistry::loadAnnotationClass($className);
+    }
 }


### PR DESCRIPTION
This method allows consumers of this library to add loaders without
worrying about the performance implications of adding the same loader
multiple times.

Refs #145 
Refs #161