### PR TITLE
Enhancement: Use short list syntax

### DIFF
--- a/lib/Doctrine/Common/Annotations/DocParser.php
+++ b/lib/Doctrine/Common/Annotations/DocParser.php
@@ -919,7 +919,7 @@ final class DocParser
         $identifier = $this->Identifier();
 
         if ( ! defined($identifier) && false !== strpos($identifier, '::') && '\\' !== $identifier[0]) {
-            list($className, $const) = explode('::', $identifier);
+            [$className, $const] = explode('::', $identifier);
 
             $pos = strpos($className, '\\');
             $alias = (false === $pos) ? $className : substr($className, 0, $pos);
@@ -1121,7 +1121,7 @@ final class DocParser
         $this->match(DocLexer::T_CLOSE_CURLY_BRACES);
 
         foreach ($values as $value) {
-            list ($key, $val) = $value;
+            [$key, $val] = $value;
 
             if ($key !== null) {
                 $array[$key] = $val;


### PR DESCRIPTION
This PR

* [x] uses short `list()` syntax