### PR TITLE
Enhancement: Use doctrine/coding-standard

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,4 +2,5 @@
 .gitattributes export-ignore
 .gitignore export-ignore
 .travis.yml export-ignore
+phpcs.xml.dist export-ignore
 phpunit.xml.dist export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 vendor/
 composer.lock
 composer.phar
+phpcs.xml
 phpunit.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,3 +29,7 @@ jobs:
       before_script:
         - travis_retry composer require --dev --prefer-dist --prefer-stable phpstan/phpstan:^0.7
       script: vendor/bin/phpstan analyse -l 3 -c phpstan.neon lib tests
+
+    - stage: Coding standard
+      script:
+        - ./vendor/bin/phpcs

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     },
     "require-dev": {
         "doctrine/cache": "1.*",
+        "doctrine/coding-standard": "^2.1.0",
         "phpunit/phpunit": "^7.0"
     },
     "autoload": {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<ruleset name="PHPCS Coding Standards for doctrine/coding-standards">
+    <arg name="basepath" value="."/>
+    <arg name="extensions" value="php"/>
+    <arg name="colors" />
+
+    <!-- Show progress of the run -->
+    <arg value="p"/>
+
+    <rule ref="Doctrine"/>
+
+    <file>lib</file>
+    <file>tests</file>
+</ruleset>


### PR DESCRIPTION
❗️ Blocked by #174.

This PR

* [x] requires `doctrine/coding-standard` and adds a `coding standard` stage
* [ ] runs `phpcbf` (so far, **3x**)