### PR TITLE
Enhancement: Keep packages sorted

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,9 @@
         "doctrine/cache": "1.*",
         "phpunit/phpunit": "^7.0"
     },
+    "config": {
+        "sort-packages": true
+    },
     "autoload": {
         "psr-4": { "Doctrine\\Common\\Annotations\\": "lib/Doctrine/Common/Annotations" }
     },


### PR DESCRIPTION
This PR

* [x] keeps packages sorted in `composer.json`

💁‍♂️ For reference, see https://getcomposer.org/doc/06-config.md#sort-packages.