### PR TITLE
Fix: Add test for __get() and __set()

### DIFF
--- a/tests/Doctrine/Tests/Common/Annotations/AnnotationTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/AnnotationTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Doctrine\Tests\Common\Annotations;
+
+use Doctrine\Common\Annotations\Annotation;
+use PHPUnit\Framework\TestCase;
+
+final class AnnotationTest extends TestCase
+{
+    public function testMagicGetThrowsBadMethodCallException()
+    {
+        $name = 'foo';
+
+        $annotation = new Annotation([]);
+
+        $this->expectException(\BadMethodCallException::class);
+        $this->expectExceptionMessage(sprintf(
+            "Unknown property '%s' on annotation '%s'.",
+            $name,
+            Annotation::class
+        ));
+
+        $annotation->{$name};
+    }
+
+    public function testMagicSetThrowsBadMethodCallException()
+    {
+        $name = 'foo';
+
+        $annotation = new Annotation([]);
+
+        $this->expectException(\BadMethodCallException::class);
+        $this->expectExceptionMessage(sprintf(
+            "Unknown property '%s' on annotation '%s'.",
+            $name,
+            Annotation::class
+        ));
+
+        $annotation->{$name} = 9001;
+    }
+}


### PR DESCRIPTION
This PR

* [x] covers `Annotation::__get()` and `Annotation::__set()`