### PR TITLE
Add support for class name constants that resolve to imported classes

### DIFF
--- a/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
@@ -841,6 +841,10 @@ DOCBLOCK;
             AnnotationWithConstants::class
         );
         $provider[] = array(
+            '@AnnotationWithConstants(AnnotationWithConstants)',
+            AnnotationWithConstants::class
+        );
+        $provider[] = array(
             '@AnnotationWithConstants({AnnotationWithConstants::class = AnnotationWithConstants::class})',
             array(AnnotationWithConstants::class => AnnotationWithConstants::class)
         );


### PR DESCRIPTION
Currently annotations that accept a parameter of a given type can be
used via:

```
use Foo\Bar\SomeClass;

...

@SomeAnnotation(SomeClass::class)
protected $property;
```

This works fine, but as a minor improvement we can drop the requirement
for `::class` and simply resolve the type against the imported classes
that Doctrine already tracks (similar to how annotations are resolved):

```
@SomeAnnotation(SomeClass) protected $property;
```