### PR TITLE
Fix package name to  doctrine/annotations

### DIFF
--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -30,7 +30,7 @@ You can install the Annotation component with composer:
 
 .. code-block::
 
-    $ composer require doctrine/annotation
+    $ composer require doctrine/annotations
 
 Create an annotation class
 ==========================


### PR DESCRIPTION
There is no doctrine/annotation package, the right package name is
doctrine/annotations.