### PR TITLE
Change Annotation::value typehint to mixed

### DIFF
--- a/lib/Doctrine/Annotations/Annotation.php
+++ b/lib/Doctrine/Annotations/Annotation.php
@@ -15,7 +15,7 @@ class Annotation
     /**
      * Value property. Common among all derived classes.
      *
-     * @var string
+     * @var mixed
      */
     public $value;
 


### PR DESCRIPTION
`string` is wrong as it can also be `null` or an `array`. Merging this (and tagging a new bugfix release) would help me with https://github.com/doctrine/mongodb-odm/pull/1803 :)