### PR TITLE
[DocParser] Prevent reflection on ignored annotations when namespaces are present.

### DIFF
--- a/lib/Doctrine/Annotations/DocParser.php
+++ b/lib/Doctrine/Annotations/DocParser.php
@@ -667,6 +667,9 @@ final class DocParser
             $loweredAlias = strtolower($alias);
 
             if ($this->namespaces) {
+                if (isset($this->ignoredAnnotationNames[$name])) {
+                    return false;
+                }
                 foreach ($this->namespaces as $namespace) {
                     if ($this->classExists($namespace.'\\'.$name)) {
                         $name = $namespace.'\\'.$name;

--- a/tests/Doctrine/Tests/Annotations/DocParserTest.php
+++ b/tests/Doctrine/Tests/Annotations/DocParserTest.php
@@ -1379,11 +1379,16 @@ DOCBLOCK;
 
     }
 
+    /**
+     * Ensure annotations can be ignored when namespaces are present.
+     *
+     * DocParser should never use class_exists() on an ignored annotation,
+     * including cases where namespaces are set.
+     */
     public function testIgnoredAnnotationSkippedBeforeReflection() {
         $annotation = 'neverReflectThis';
         $parser = new DocParser();
         $parser->setIgnoredAnnotationNames([$annotation => TRUE]);
-//        $parser->setIgnoreNotImportedAnnotations(TRUE);
         $parser->addNamespace('\\Arbitrary\\Namespace');
 
         // Register our class loader which will fail if the parser tries to

--- a/tests/Doctrine/Tests/Annotations/DocParserTest.php
+++ b/tests/Doctrine/Tests/Annotations/DocParserTest.php
@@ -1378,6 +1378,29 @@ DOCBLOCK;
         self::assertCount(1, $result);
 
     }
+
+    public function testIgnoredAnnotationSkippedBeforeReflection() {
+        $annotation = 'neverReflectThis';
+        $parser = new DocParser();
+        $parser->setIgnoredAnnotationNames([$annotation => TRUE]);
+//        $parser->setIgnoreNotImportedAnnotations(TRUE);
+        $parser->addNamespace('\\Arbitrary\\Namespace');
+
+        // Register our class loader which will fail if the parser tries to
+        // autoload disallowed annotations.
+        $autoloader = function ($class_name) use ($annotation) {
+            $name_array = explode('\\', $class_name);
+            $name = array_pop($name_array);
+            if ($name == $annotation) {
+                $this->fail('Attempted to autoload an ignored annotation: ' . $name);
+            }
+        };
+        spl_autoload_register($autoloader, TRUE, TRUE);
+        // Perform the parse.
+        $this->assertEmpty($parser->parse('@neverReflectThis'));
+        // Clean up after ourselves.
+        spl_autoload_unregister($autoloader);
+    }
 }
 
 /** @Annotation */


### PR DESCRIPTION
I'm working on some Drupal core stuff.

We use doctrine/common and doctrine/annotations.

Our classes have lots of annotations like `@param` and `@return` that we want to ignore. However, our systems end up hitting reflection with class names like `Drupal\Something\param`. This is bad because it means we have at least one `file_exists()` per reflection.

In this issue we've written a test to prove that our subsystems do this: https://www.drupal.org/project/drupal/issues/2557433

We also have issues to roll our own replacements for some pieces of the Doctrine annotation system: https://www.drupal.org/project/drupal/issues/2631202

However, we can't proceed because `DocParser` never ignores annotation tags if namespaces are in use.

This PR has a test which fails if `DocParser` tries to autoload a name that's in the ignore list, and then makes this test pass.

Thanks for considering it.

Drupal is currently stuck at doctrine/annotations v1.2.7, because we support PHP 5.5 and up. So if this fix could find its way back in time that would help us immensely. Thanks.