### PR TITLE
Document correct method usage

### DIFF
--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -69,7 +69,10 @@ access the annotations of a class. A common one is
     $property = $reflectionClass->getProperty('bar');
 
     $reader = new AnnotationReader();
-    $myAnnotation = $reader->getPropertyAnnotation($property, 'bar');
+    $myAnnotation = $reader->getPropertyAnnotation(
+        $property,
+        MyAnnotation::class
+    );
 
     echo $myAnnotation->myProperty; // result: "value"
 


### PR DESCRIPTION
The second argument is supposed to be the Annotation you want to get,
the property name is already contained in $property.