### PR TITLE
Added `@phpcsSuppress` to globally ignored annotations

### DIFF
--- a/lib/Doctrine/Annotations/AnnotationReader.php
+++ b/lib/Doctrine/Annotations/AnnotationReader.php
@@ -84,7 +84,9 @@ class AnnotationReader implements Reader
         // PlantUML
         'startuml' => true, 'enduml' => true,
         // Symfony 3.3 Cache Adapter
-        'experimental' => true
+        'experimental' => true,
+        // Slevomat Coding Standard
+        'phpcsSuppress' => true
     ];
 
     /**


### PR DESCRIPTION
Added `@phpcsSuppress` from [Slevomat Coding Standard](https://github.com/slevomat/coding-standard) to globally ignored annotations list.