### PR TITLE
Added PHP CodeSniffer tags to globally ignored annotations list.

### DIFF
--- a/lib/Doctrine/Annotations/AnnotationReader.php
+++ b/lib/Doctrine/Annotations/AnnotationReader.php
@@ -86,7 +86,10 @@ class AnnotationReader implements Reader
         // Symfony 3.3 Cache Adapter
         'experimental' => true,
         // Slevomat Coding Standard
-        'phpcsSuppress' => true
+        'phpcsSuppress' => true,
+        // PHP CodeSniffer
+        'codingStandardsIgnoreStart' => true,
+        'codingStandardsIgnoreEnd' => true,
     ];
 
     /**


### PR DESCRIPTION
Added `@codingStandardsIgnoreStart` and `@codingStandardsIgnoreEnd` from PHP CodeSniffer to globally ignored annotations list.

Sorry for not including this tags in previous PR. At that moment I don't know about this tags :)