### PR TITLE
Remove a VersionEye badge from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Doctrine Annotations
 
 [![Build Status](https://travis-ci.org/doctrine/annotations.svg?branch=master)](https://travis-ci.org/doctrine/annotations)
-[![Dependency Status](https://www.versioneye.com/package/php--doctrine--annotations/badge.png)](https://www.versioneye.com/package/php--doctrine--annotations)
 [![Reference Status](https://www.versioneye.com/php/doctrine:annotations/reference_badge.svg)](https://www.versioneye.com/php/doctrine:annotations/references)
 [![Total Downloads](https://poser.pugx.org/doctrine/annotations/downloads.png)](https://packagist.org/packages/doctrine/annotations)
 [![Latest Stable Version](https://poser.pugx.org/doctrine/annotations/v/stable.png)](https://packagist.org/packages/doctrine/annotations)


### PR DESCRIPTION
[VersionEye is no more.](https://blog.versioneye.com/2017/10/19/versioneye-sunset-process/)