### PR TITLE
Update AnnotationReader's metadata parser to use list of known ignored annotation 

### DIFF
--- a/lib/Doctrine/Annotations/AnnotationReader.php
+++ b/lib/Doctrine/Annotations/AnnotationReader.php
@@ -181,6 +181,7 @@ class AnnotationReader implements Reader
 
         $this->preParser->setImports(self::$globalImports);
         $this->preParser->setIgnoreNotImportedAnnotations(true);
+        $this->preParser->setIgnoredAnnotationNames(self::$globalIgnoredNames);
 
         $this->phpParser = new PhpParser;
     }

--- a/tests/Doctrine/Tests/Annotations/AbstractReaderTest.php
+++ b/tests/Doctrine/Tests/Annotations/AbstractReaderTest.php
@@ -408,6 +408,28 @@ abstract class AbstractReaderTest extends TestCase
         self::assertEmpty($reader->getPropertyAnnotations($class->getProperty('foo')));
     }
 
+    public function testGloballyIgnoredAnnotationNotIgnored() : void
+    {
+        $reader = $this->getReader();
+        $class  = new \ReflectionClass(Fixtures\ClassDDC1660::class);
+
+        $testLoader = static function (string $className) : bool {
+            if ($className === 'since') {
+                throw new \InvalidArgumentException('Globally ignored annotation names should never be passed to an autoloader.');
+            }
+
+            return false;
+        };
+
+        spl_autoload_register($testLoader, true, true);
+
+        try {
+            self::assertEmpty($reader->getClassAnnotations($class));
+        } finally {
+            spl_autoload_unregister($testLoader);
+        }
+    }
+
     public function testAnnotationEnumeratorException()
     {
         $reader     = $this->getReader();


### PR DESCRIPTION
A parser used to collect parsing metadata basically ignores a known list of globally ignored annotation names, goes through loops checking annotations that do not need any checking. Let's fix that by communicating the list during initialization.

E.g. these checks should not be evaluated for known ignored annotations:

https://github.com/doctrine/annotations/blob/386d3bb15db36fd2a381d90fe5ab9287984aba42/lib/Doctrine/Annotations/DocParser.php#L682-L690

Please let me know if this change needs a test. One way to test is to rig an additional autoloader that would fail on attempt to load a class named as one of the commonly-ignored annotations like `@see`.