### PR TITLE
[docs, 1.6] Fixed a wrong introduction sample code

### DIFF
--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -69,7 +69,10 @@ access the annotations of a class. A common one is
     $property = $reflectionClass->getProperty('bar');
 
     $reader = new AnnotationReader();
-    $myAnnotation = $reader->getPropertyAnnotation($property, 'bar');
+    $myAnnotation = $reader->getPropertyAnnotation(
+        $property,
+        MyAnnotation::class
+    );
 
     echo $myAnnotation->myProperty; // result: "value"
 


### PR DESCRIPTION
Fixed #228 in 1.6 branch by replacing 'bar' with an annotation class name.