### PR TITLE
Extract implicitly ignored annotation names to separate class

### DIFF
--- a/lib/Doctrine/Annotations/AnnotationReader.php
+++ b/lib/Doctrine/Annotations/AnnotationReader.php
@@ -35,62 +35,7 @@ class AnnotationReader implements Reader
      *
      * @var array
      */
-    private static $globalIgnoredNames = [
-        // Annotation tags
-        'Annotation' => true, 'Attribute' => true, 'Attributes' => true,
-        /* Can we enable this? 'Enum' => true, */
-        'Required' => true,
-        'Target' => true,
-        // Widely used tags (but not existent in phpdoc)
-        'fix' => true , 'fixme' => true,
-        'override' => true,
-        // PHPDocumentor 1 tags
-        'abstract'=> true, 'access'=> true,
-        'code' => true,
-        'deprec'=> true,
-        'endcode' => true, 'exception'=> true,
-        'final'=> true,
-        'ingroup' => true, 'inheritdoc'=> true, 'inheritDoc'=> true,
-        'magic' => true,
-        'name'=> true,
-        'toc' => true, 'tutorial'=> true,
-        'private' => true,
-        'static'=> true, 'staticvar'=> true, 'staticVar'=> true,
-        'throw' => true,
-        // PHPDocumentor 2 tags.
-        'api' => true, 'author'=> true,
-        'category'=> true, 'copyright'=> true,
-        'deprecated'=> true,
-        'example'=> true,
-        'filesource'=> true,
-        'global'=> true,
-        'ignore'=> true, /* Can we enable this? 'index' => true, */ 'internal'=> true,
-        'license'=> true, 'link'=> true,
-        'method' => true,
-        'package'=> true, 'param'=> true, 'property' => true, 'property-read' => true, 'property-write' => true,
-        'return'=> true,
-        'see'=> true, 'since'=> true, 'source' => true, 'subpackage'=> true,
-        'throws'=> true, 'todo'=> true, 'TODO'=> true,
-        'usedby'=> true, 'uses' => true,
-        'var'=> true, 'version'=> true,
-        // PHPUnit tags
-        'codeCoverageIgnore' => true, 'codeCoverageIgnoreStart' => true, 'codeCoverageIgnoreEnd' => true,
-        // PHPCheckStyle
-        'SuppressWarnings' => true,
-        // PHPStorm
-        'noinspection' => true,
-        // PEAR
-        'package_version' => true,
-        // PlantUML
-        'startuml' => true, 'enduml' => true,
-        // Symfony 3.3 Cache Adapter
-        'experimental' => true,
-        // Slevomat Coding Standard
-        'phpcsSuppress' => true,
-        // PHP CodeSniffer
-        'codingStandardsIgnoreStart' => true,
-        'codingStandardsIgnoreEnd' => true,
-    ];
+    private static $globalIgnoredNames = ImplicitlyIgnoredAnnotationNames::LIST;
 
     /**
      * A list with annotations that are not causing exceptions when not resolved to an annotation class.

--- a/lib/Doctrine/Annotations/ImplicitlyIgnoredAnnotationNames.php
+++ b/lib/Doctrine/Annotations/ImplicitlyIgnoredAnnotationNames.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Annotations;
+
+/**
+ *  A list of annotations that are implicitly ignored during the parsing process.
+ *
+ *  All names are case sensitive.
+ */
+final class ImplicitlyIgnoredAnnotationNames
+{
+    private const Reserved = [
+        'Annotation' => true,
+        'Attribute'  => true,
+        'Attributes' => true,
+        /* Can we enable this? 'Enum' => true, */
+        'Required'   => true,
+        'Target'     => true,
+    ];
+
+    private const WidelyUsedNonStandard = [
+        'fix'      => true,
+        'fixme'    => true,
+        'override' => true,
+    ];
+
+    private const PhpDocumentor1 = [
+        'abstract'   => true,
+        'access'     => true,
+        'code'       => true,
+        'deprec'     => true,
+        'endcode'    => true,
+        'exception'  => true,
+        'final'      => true,
+        'ingroup'    => true,
+        'inheritdoc' => true,
+        'inheritDoc' => true,
+        'magic'      => true,
+        'name'       => true,
+        'private'    => true,
+        'static'     => true,
+        'staticvar'  => true,
+        'staticVar'  => true,
+        'toc'        => true,
+        'tutorial'   => true,
+        'throw'      => true,
+    ];
+
+    private const PhpDocumentor2 = [
+        'api'            => true,
+        'author'         => true,
+        'category'       => true,
+        'copyright'      => true,
+        'deprecated'     => true,
+        'example'        => true,
+        'filesource'     => true,
+        'global'         => true,
+        'ignore'         => true,
+        /* Can we enable this? 'index' => true, */
+        'internal'       => true,
+        'license'        => true,
+        'link'           => true,
+        'method'         => true,
+        'package'        => true,
+        'param'          => true,
+        'property'       => true,
+        'property-read'  => true,
+        'property-write' => true,
+        'return'         => true,
+        'see'            => true,
+        'since'          => true,
+        'source'         => true,
+        'subpackage'     => true,
+        'throws'         => true,
+        'todo'           => true,
+        'TODO'           => true,
+        'usedby'         => true,
+        'uses'           => true,
+        'var'            => true,
+        'version'        => true,
+    ];
+
+    private const PHPUnit = [
+        'codeCoverageIgnore'      => true,
+        'codeCoverageIgnoreEnd'   => true,
+        'codeCoverageIgnoreStart' => true,
+    ];
+
+    private const PhpCheckStyle = [
+        'SuppressWarnings' => true,
+    ];
+
+    private const PhpStorm = [
+        'noinspection' => true,
+    ];
+
+    private const PEAR = [
+        'package_version' => true,
+    ];
+
+    private const PlainUML = [
+        'startuml' => true,
+        'enduml'   => true,
+    ];
+
+    private const Symfony = [
+        'experimental' => true,
+    ];
+
+    private const PhpCodeSniffer = [
+        'codingStandardsIgnoreStart' => true,
+        'codingStandardsIgnoreEnd'   => true,
+    ];
+
+    private const SlevomatCodingStandard = [
+        'phpcsSuppress' => true,
+    ];
+
+    public const LIST = self::Reserved
+        + self::WidelyUsedNonStandard
+        + self::PhpDocumentor1
+        + self::PhpDocumentor2
+        + self::PHPUnit
+        + self::PhpCheckStyle
+        + self::PhpStorm
+        + self::PEAR
+        + self::PlainUML
+        + self::Symfony
+        + self::SlevomatCodingStandard
+        + self::PhpCodeSniffer;
+
+    private function __construct()
+    {
+    }
+}


### PR DESCRIPTION
* To improve readability and maintainability of this list.
* Categorized, each category ordered alphabetically.
* Will be further used in Annotations 2.0.