### PR TITLE
fix ignored annotations with namespace alias

### DIFF
--- a/lib/Doctrine/Common/Annotations/DocParser.php
+++ b/lib/Doctrine/Common/Annotations/DocParser.php
@@ -703,10 +703,10 @@ final class DocParser
                     }
                 }
             } elseif (isset($this->imports[$loweredAlias])) {
-                $found = true;
                 $name  = (false !== $pos)
                     ? $this->imports[$loweredAlias] . substr($name, $pos)
                     : $this->imports[$loweredAlias];
+                $found = $this->classExists($name);
             } elseif ( ! isset($this->ignoredAnnotationNames[$name])
                 && isset($this->imports['__NAMESPACE__'])
                 && $this->classExists($this->imports['__NAMESPACE__'] . '\\' . $name)


### PR DESCRIPTION
when i set a namespace to ignored but use a namespace alias, there was no check if the class actually exists. instead of ignoring, we ended up with an exception that the annotation could not be autoloaded.