### PR TITLE
fix ignored annotations with namespace alias

### DIFF
--- a/lib/Doctrine/Common/Annotations/DocParser.php
+++ b/lib/Doctrine/Common/Annotations/DocParser.php
@@ -710,10 +710,11 @@ final class DocParser
                     }
                 }
             } elseif (isset($this->imports[$loweredAlias])) {
-                $found = true;
-                $name  = (false !== $pos)
-                    ? $this->imports[$loweredAlias] . substr($name, $pos)
-                    : $this->imports[$loweredAlias];
+                $namespace = ltrim($this->imports[$loweredAlias], '\\');
+                $name = (false !== $pos)
+                    ? $namespace . substr($name, $pos)
+                    : $namespace;
+                $found = $this->classExists($name);
             } elseif ( ! isset($this->ignoredAnnotationNames[$name])
                 && isset($this->imports['__NAMESPACE__'])
                 && $this->classExists($this->imports['__NAMESPACE__'] . '\\' . $name)

--- a/tests/Doctrine/Tests/Common/Annotations/AnnotationReaderTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/AnnotationReaderTest.php
@@ -12,6 +12,7 @@ use Doctrine\Tests\Common\Annotations\Fixtures\ClassWithPhpCsSuppressAnnotation;
 use Doctrine\Tests\Common\Annotations\Fixtures\IgnoredNamespaces\AnnotatedAtClassLevel;
 use Doctrine\Tests\Common\Annotations\Fixtures\IgnoredNamespaces\AnnotatedAtMethodLevel;
 use Doctrine\Tests\Common\Annotations\Fixtures\IgnoredNamespaces\AnnotatedAtPropertyLevel;
+use Doctrine\Tests\Common\Annotations\Fixtures\IgnoredNamespaces\AnnotatedWithAlias;
 
 class AnnotationReaderTest extends AbstractReaderTest
 {
@@ -108,6 +109,21 @@ class AnnotationReaderTest extends AbstractReaderTest
     {
         $reader = $this->getReader();
         $ref = new \ReflectionClass(AnnotatedAtPropertyLevel::class);
+
+        $reader::addGlobalIgnoredNamespace('SomePropertyAnnotationNamespace');
+
+        self::assertEmpty($reader->getPropertyAnnotations($ref->getProperty('property')));
+    }
+
+    /**
+     * @group 244
+     *
+     * @runInSeparateProcess
+     */
+    public function testAnnotationWithAliasIsIgnored(): void
+    {
+        $reader = $this->getReader();
+        $ref = new \ReflectionClass(AnnotatedWithAlias::class);
 
         $reader::addGlobalIgnoredNamespace('SomePropertyAnnotationNamespace');
 

--- a/tests/Doctrine/Tests/Common/Annotations/Fixtures/IgnoredNamespaces/AnnotatedWithAlias.php
+++ b/tests/Doctrine/Tests/Common/Annotations/Fixtures/IgnoredNamespaces/AnnotatedWithAlias.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Doctrine\Tests\Common\Annotations\Fixtures\IgnoredNamespaces;
+
+use SomePropertyAnnotationNamespace\Subnamespace as SomeAlias;
+
+class AnnotatedWithAlias
+{
+    /**
+     * @SomeAlias\Name
+     */
+    private $property;
+}


### PR DESCRIPTION
when i set a namespace to ignored but use a namespace alias, there was no check if the class actually exists. instead of ignoring, we ended up with an exception that the annotation could not be autoloaded.