### PR TITLE
Introduce annotation metadata

### DIFF
--- a/lib/Doctrine/Annotations/Annotation/Target.php
+++ b/lib/Doctrine/Annotations/Annotation/Target.php
@@ -2,6 +2,8 @@
 
 namespace Doctrine\Annotations\Annotation;
 
+use Doctrine\Annotations\Metadata\AnnotationTarget;
+
 /**
  * Annotation that can be used to signal to the parser
  * to check the annotation target during the parsing process.
@@ -12,11 +14,11 @@ namespace Doctrine\Annotations\Annotation;
  */
 final class Target
 {
-    const TARGET_CLASS              = 1;
-    const TARGET_METHOD             = 2;
-    const TARGET_PROPERTY           = 4;
-    const TARGET_ANNOTATION         = 8;
-    const TARGET_ALL                = 15;
+    public const TARGET_CLASS      = AnnotationTarget::TARGET_CLASS;
+    public const TARGET_METHOD     = AnnotationTarget::TARGET_METHOD;
+    public const TARGET_PROPERTY   = AnnotationTarget::TARGET_PROPERTY;
+    public const TARGET_ANNOTATION = AnnotationTarget::TARGET_ANNOTATION;
+    public const TARGET_ALL        = AnnotationTarget::TARGET_ALL;
 
     /**
      * @var array

--- a/lib/Doctrine/Annotations/Metadata/AnnotationMetadata.php
+++ b/lib/Doctrine/Annotations/Metadata/AnnotationMetadata.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Annotations\Metadata;
+
+use Doctrine\Annotations\Metadata\Exception\TooManyDefaultProperties;
+use function array_combine;
+use function array_filter;
+use function array_map;
+use function array_values;
+use function count;
+
+/**
+ * Annotation metadata represents information about the definition a single annotation - its name, allowed targets,
+ * construction strategy and properties.
+ */
+final class AnnotationMetadata
+{
+    /** @var string */
+    private $name;
+
+    /** @var AnnotationTarget */
+    private $target;
+
+    /** @var bool */
+    private $usesConstructor;
+
+    /** @var array<string, PropertyMetadata> */
+    private $properties;
+
+    /** @var PropertyMetadata|null */
+    private $defaultProperty;
+
+    /**
+     * @param PropertyMetadata[] $properties
+     */
+    public function __construct(
+        string $name,
+        AnnotationTarget $target,
+        bool $hasConstructor,
+        PropertyMetadata ...$properties
+    ) {
+        $this->name            = $name;
+        $this->target          = $target;
+        $this->usesConstructor = $hasConstructor;
+        $this->properties      = array_combine(
+            array_map(
+                static function (PropertyMetadata $property) : string {
+                    return $property->getName();
+                },
+                $properties
+            ),
+            $properties
+        );
+
+        $defaultProperties = array_filter(
+            $properties,
+            static function (PropertyMetadata $property) : bool {
+                return $property->isDefault();
+            }
+        );
+
+        if (count($defaultProperties) > 1) {
+            throw TooManyDefaultProperties::new($name, ...$defaultProperties);
+        }
+
+        $this->defaultProperty = array_values($defaultProperties)[0] ?? null;
+    }
+
+    public function getName() : string
+    {
+        return $this->name;
+    }
+
+    public function getTarget() : AnnotationTarget
+    {
+        return $this->target;
+    }
+
+    public function usesConstructor() : bool
+    {
+        return $this->usesConstructor;
+    }
+
+    /**
+     * @return array<string, PropertyMetadata>
+     */
+    public function getProperties() : array
+    {
+        return $this->properties;
+    }
+
+    public function getDefaultProperty() : ?PropertyMetadata
+    {
+        return $this->defaultProperty;
+    }
+}

--- a/lib/Doctrine/Annotations/Metadata/AnnotationTarget.php
+++ b/lib/Doctrine/Annotations/Metadata/AnnotationTarget.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Annotations\Metadata;
+
+use Doctrine\Annotations\Annotation\Target;
+use Doctrine\Annotations\Metadata\Exception\InvalidAnnotationTarget;
+use const ARRAY_FILTER_USE_KEY;
+use function array_filter;
+use function implode;
+
+/**
+ * Annotation targets represents possible targets at which an annotation could be declared.
+ */
+final class AnnotationTarget
+{
+    public const TARGET_CLASS      = 1;
+    public const TARGET_METHOD     = 2;
+    public const TARGET_PROPERTY   = 4;
+    public const TARGET_ANNOTATION = 8;
+    public const TARGET_ALL        = self::TARGET_CLASS
+        | self::TARGET_METHOD
+        | self::TARGET_PROPERTY
+        | self::TARGET_ANNOTATION;
+
+    private const LABELS = [
+        self::TARGET_CLASS      => 'CLASS',
+        self::TARGET_METHOD     => 'METHOD',
+        self::TARGET_PROPERTY   => 'PROPERTY',
+        self::TARGET_ANNOTATION => 'ANNOTATION',
+        self::TARGET_ALL        => 'ALL',
+    ];
+
+    /** @var int */
+    private $target;
+
+    /**
+     * @throws InvalidAnnotationTarget
+     */
+    public function __construct(int $target)
+    {
+        if ($target < 0 || $target > self::TARGET_ALL) {
+            throw InvalidAnnotationTarget::fromInvalidBitmask($target);
+        }
+
+        $this->target = $target;
+    }
+
+    public static function class() : self
+    {
+        return new self(self::TARGET_CLASS);
+    }
+
+    public static function method() : self
+    {
+        return new self(self::TARGET_METHOD);
+    }
+
+    public static function property() : self
+    {
+        return new self(self::TARGET_PROPERTY);
+    }
+
+    public static function annotation() : self
+    {
+        return new self(self::TARGET_ANNOTATION);
+    }
+
+    public static function all() : self
+    {
+        return new self(self::TARGET_ALL);
+    }
+
+    public static function fromAnnotation(Target $annotation) : self
+    {
+        return new self($annotation->targets);
+    }
+
+    public function unwrap() : int
+    {
+        return $this->target;
+    }
+
+    public function targetsClass() : bool
+    {
+        return ($this->target & self::TARGET_CLASS) === self::TARGET_CLASS;
+    }
+
+    public function targetsMethod() : bool
+    {
+        return ($this->target & self::TARGET_METHOD) === self::TARGET_METHOD;
+    }
+
+    public function targetsProperty() : bool
+    {
+        return ($this->target & self::TARGET_PROPERTY) === self::TARGET_PROPERTY;
+    }
+
+    public function targetsAnnotation() : bool
+    {
+        return ($this->target & self::TARGET_ANNOTATION) === self::TARGET_ANNOTATION;
+    }
+
+    public function describe() : string
+    {
+        if ($this->target === self::TARGET_ALL) {
+            return self::LABELS[self::TARGET_ALL];
+        }
+
+        return implode(
+            ', ',
+            array_filter(
+                self::LABELS,
+                function (int $target) : bool {
+                    return ($this->target & $target) === $target;
+                },
+                ARRAY_FILTER_USE_KEY
+            )
+        );
+    }
+}

--- a/lib/Doctrine/Annotations/Metadata/Builder/AnnotationMetadataBuilder.php
+++ b/lib/Doctrine/Annotations/Metadata/Builder/AnnotationMetadataBuilder.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Annotations\Metadata\Builder;
+
+use Doctrine\Annotations\Metadata\AnnotationMetadata;
+use Doctrine\Annotations\Metadata\AnnotationTarget;
+use Doctrine\Annotations\Metadata\PropertyMetadata;
+
+/**
+ * @internal
+ */
+final class AnnotationMetadataBuilder
+{
+    /** @var string */
+    private $name;
+
+    /** @var AnnotationTarget */
+    private $target;
+
+    /** @var PropertyMetadata[] */
+    private $properties = [];
+
+    /** @var bool */
+    private $usesConstructor = false;
+
+    public function __construct(string $name)
+    {
+        $this->name   = $name;
+        $this->target = AnnotationTarget::all();
+    }
+
+    public function withTarget(AnnotationTarget $target) : self
+    {
+        $this->target = $target;
+
+        return $this;
+    }
+
+    public function withUsingConstructor() : self
+    {
+        $this->usesConstructor = true;
+
+        return $this;
+    }
+
+    public function withProperty(PropertyMetadata $property) : self
+    {
+        $this->properties[] = $property;
+
+        return $this;
+    }
+
+    public function build() : AnnotationMetadata
+    {
+        return new AnnotationMetadata(
+            $this->name,
+            $this->target,
+            $this->usesConstructor,
+            ...$this->properties
+        );
+    }
+}

--- a/lib/Doctrine/Annotations/Metadata/Builder/PropertyMetadataBuilder.php
+++ b/lib/Doctrine/Annotations/Metadata/Builder/PropertyMetadataBuilder.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Annotations\Metadata\Builder;
+
+use Doctrine\Annotations\Metadata\PropertyMetadata;
+
+/**
+ * @internal
+ */
+final class PropertyMetadataBuilder
+{
+    /** @var string */
+    private $name;
+
+    /** @var string[]|null */
+    private $type;
+
+    /** @var bool */
+    private $required = false;
+
+    /** @var bool */
+    private $default = false;
+
+    /** @var array<int|float|string|bool>|null */
+    private $enum;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @param string[] $type
+     */
+    public function withType(array $type) : self
+    {
+        $this->type = $type;
+
+        return $this;
+    }
+
+    public function withBeingRequired() : self
+    {
+        $this->required = true;
+
+        return $this;
+    }
+
+    public function withBeingDefault() : self
+    {
+        $this->default = true;
+
+        return $this;
+    }
+
+    /**
+     * @param array<int|float|string|bool>|null $enum
+     */
+    public function withEnum(array $enum) : self
+    {
+        $this->enum = $enum;
+
+        return $this;
+    }
+
+    public function build() : PropertyMetadata
+    {
+        return new PropertyMetadata(
+            $this->name,
+            $this->type,
+            $this->required,
+            $this->default,
+            $this->enum
+        );
+    }
+}

--- a/lib/Doctrine/Annotations/Metadata/Exception/InvalidAnnotationTarget.php
+++ b/lib/Doctrine/Annotations/Metadata/Exception/InvalidAnnotationTarget.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Annotations\Metadata\Exception;
+
+use InvalidArgumentException;
+use function sprintf;
+
+final class InvalidAnnotationTarget extends InvalidArgumentException
+{
+    public static function fromInvalidBitmask(int $bitmask) : self
+    {
+        return new self(sprintf('Annotation target "%d" is not valid bitmask of allowed targets.', $bitmask));
+    }
+}

--- a/lib/Doctrine/Annotations/Metadata/Exception/MetadataAlreadyExists.php
+++ b/lib/Doctrine/Annotations/Metadata/Exception/MetadataAlreadyExists.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Annotations\Metadata\Exception;
+
+use Doctrine\Annotations\Metadata\AnnotationMetadata;
+use InvalidArgumentException;
+use function sprintf;
+
+final class MetadataAlreadyExists extends InvalidArgumentException
+{
+    public static function new(AnnotationMetadata $metadata) : self
+    {
+        return new self(sprintf('Metadata for annotation "%s" already exists.', $metadata->getName()));
+    }
+}

--- a/lib/Doctrine/Annotations/Metadata/Exception/MetadataDoesNotExist.php
+++ b/lib/Doctrine/Annotations/Metadata/Exception/MetadataDoesNotExist.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Annotations\Metadata\Exception;
+
+use RuntimeException;
+use function sprintf;
+
+final class MetadataDoesNotExist extends RuntimeException
+{
+    public static function new(string $name) : self
+    {
+        return new self(sprintf('Metadata for annotation "%s" does not exist.', $name));
+    }
+}

--- a/lib/Doctrine/Annotations/Metadata/Exception/TooManyDefaultProperties.php
+++ b/lib/Doctrine/Annotations/Metadata/Exception/TooManyDefaultProperties.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Annotations\Metadata\Exception;
+
+use Doctrine\Annotations\Metadata\PropertyMetadata;
+use LogicException;
+use function array_map;
+use function count;
+use function implode;
+use function sprintf;
+
+final class TooManyDefaultProperties extends LogicException
+{
+    public static function new(string $name, PropertyMetadata ...$properties) : self
+    {
+        return new self(
+            sprintf(
+                'The annotation "%s" can only have at most one default property, currently has %d: "%s".',
+                $name,
+                count($properties),
+                implode(
+                    '", "',
+                    array_map(
+                        static function (PropertyMetadata $property) : string {
+                            return $property->getName();
+                        },
+                        $properties
+                    )
+                )
+            )
+        );
+    }
+}

--- a/lib/Doctrine/Annotations/Metadata/InternalAnnotations.php
+++ b/lib/Doctrine/Annotations/Metadata/InternalAnnotations.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Annotations\Metadata;
+
+use Doctrine\Annotations\Annotation\Attribute;
+use Doctrine\Annotations\Annotation\Attributes;
+use Doctrine\Annotations\Annotation\Enum;
+use Doctrine\Annotations\Annotation\Target;
+
+/**
+ * Internal meta-annotations exposed by the Annotations library to declare custom user-land annotations.
+ *
+ * @internal
+ */
+final class InternalAnnotations
+{
+    public static function createMetadata() : MetadataCollection
+    {
+        return new TransientMetadataCollection(
+            new AnnotationMetadata(
+                Attribute::class,
+                AnnotationTarget::annotation(),
+                false,
+                new PropertyMetadata(
+                    'name',
+                    ['type' => 'string'],
+                    true,
+                    true
+                ),
+                new PropertyMetadata(
+                    'type',
+                    ['type' => 'string'],
+                    true
+                ),
+                new PropertyMetadata(
+                    'required',
+                    ['type' => 'boolean']
+                )
+            ),
+            new AnnotationMetadata(
+                Attributes::class,
+                AnnotationTarget::class(),
+                false,
+                new PropertyMetadata(
+                    'value',
+                    [
+                        'type'       => 'array',
+                        'array_type' =>Attribute::class,
+                        'value'      =>'array<' . Attribute::class . '>',
+                    ],
+                    true,
+                    true
+                )
+            ),
+            new AnnotationMetadata(
+                Enum::class,
+                AnnotationTarget::property(),
+                true,
+                new PropertyMetadata(
+                    'value',
+                    ['type' => 'array'],
+                    true,
+                    true
+                ),
+                new PropertyMetadata(
+                    'literal',
+                    ['type' => 'array']
+                )
+            ),
+            new AnnotationMetadata(
+                Target::class,
+                AnnotationTarget::class(),
+                true,
+                new PropertyMetadata(
+                    'value',
+                    [
+                        'type'      =>'array',
+                        'array_type'=>'string',
+                        'value'     =>'array<string>',
+                    ],
+                    false,
+                    true
+                )
+            )
+        );
+    }
+}

--- a/lib/Doctrine/Annotations/Metadata/MetadataCollection.php
+++ b/lib/Doctrine/Annotations/Metadata/MetadataCollection.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Annotations\Metadata;
+
+use Countable;
+use Doctrine\Annotations\Metadata\Exception\MetadataAlreadyExists;
+use Doctrine\Annotations\Metadata\Exception\MetadataDoesNotExist;
+use IteratorAggregate;
+use Traversable;
+
+/**
+ * Storage of all annotation metadata. This is a possible extension point i.e. for caching layer.
+ */
+interface MetadataCollection extends IteratorAggregate, Countable
+{
+    /**
+     * @throws MetadataAlreadyExists
+     */
+    public function add(AnnotationMetadata ...$metadatas) : void;
+
+    public function include(self $other) : void;
+
+    /**
+     * @throws MetadataDoesNotExist
+     */
+    public function get(string $name) : AnnotationMetadata;
+
+    public function has(string $name) : bool;
+
+    /**
+     * @return Traversable<AnnotationMetadata>
+     */
+    public function getIterator() : Traversable;
+
+    public function count() : int;
+}

--- a/lib/Doctrine/Annotations/Metadata/PropertyMetadata.php
+++ b/lib/Doctrine/Annotations/Metadata/PropertyMetadata.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Annotations\Metadata;
+
+/**
+ * Property metadata represents information about the definition of a single property of an annotation, it's name,
+ * accepted types, whether it's required and whether it's default.
+ */
+final class PropertyMetadata
+{
+    /** @var string */
+    private $name;
+
+    /** @var array<string, string>|null */
+    private $type;
+
+    /** @var bool */
+    private $required;
+
+    /** @var bool */
+    private $default;
+
+    /** @var array<int|float|string|bool>|null */
+    private $enum;
+
+    /**
+     * @param array<string, string>             $type
+     * @param array<int|float|string|bool>|null $enum
+     */
+    public function __construct(
+        string $name,
+        ?array $type,
+        bool $required = false,
+        bool $default = false,
+        ?array $enum = null
+    ) {
+        $this->name     = $name;
+        $this->type     = $type;
+        $this->required = $required;
+        $this->default  = $default;
+        $this->enum     = $enum;
+    }
+
+    public function getName() : string
+    {
+        return $this->name;
+    }
+
+    public function isRequired() : bool
+    {
+        return $this->required;
+    }
+
+    /**
+     * @return array<string, string>|null
+     */
+    public function getType() : ?array
+    {
+        return $this->type;
+    }
+
+    public function isDefault() : bool
+    {
+        return $this->default;
+    }
+
+    /**
+     * @return array<int|float|string|bool>|null
+     */
+    public function getEnum() : ?array
+    {
+        return $this->enum;
+    }
+}

--- a/lib/Doctrine/Annotations/Metadata/TransientMetadataCollection.php
+++ b/lib/Doctrine/Annotations/Metadata/TransientMetadataCollection.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Annotations\Metadata;
+
+use Doctrine\Annotations\Metadata\Exception\MetadataAlreadyExists;
+use Doctrine\Annotations\Metadata\Exception\MetadataDoesNotExist;
+use Traversable;
+use function array_key_exists;
+use function array_values;
+use function count;
+
+/**
+ * In-memory metadata collection.
+ *
+ * @internal
+ */
+final class TransientMetadataCollection implements MetadataCollection
+{
+    /** @var array<string, AnnotationMetadata> */
+    private $metadata = [];
+
+    public function __construct(AnnotationMetadata ...$metadatas)
+    {
+        $this->add(...$metadatas);
+    }
+
+    /**
+     * @throws MetadataAlreadyExists
+     */
+    public function add(AnnotationMetadata ...$metadatas) : void
+    {
+        foreach ($metadatas as $metadata) {
+            if (isset($this->metadata[$metadata->getName()])) {
+                throw MetadataAlreadyExists::new($metadata);
+            }
+
+            $this->metadata[$metadata->getName()] = $metadata;
+        }
+    }
+
+    public function include(MetadataCollection $other) : void
+    {
+        $this->add(...$other);
+    }
+
+    /**
+     * @throws MetadataDoesNotExist
+     */
+    public function get(string $name) : AnnotationMetadata
+    {
+        if (! isset($this->metadata[$name])) {
+            throw MetadataDoesNotExist::new($name);
+        }
+
+        return $this->metadata[$name];
+    }
+
+    public function has(string $name) : bool
+    {
+        return array_key_exists($name, $this->metadata);
+    }
+
+    /**
+     * @return Traversable<AnnotationMetadata>
+     */
+    public function getIterator() : Traversable
+    {
+        yield from array_values($this->metadata);
+    }
+
+    public function count() : int
+    {
+        return count($this->metadata);
+    }
+}

--- a/tests/Doctrine/Tests/Annotations/Metadata/AnnotationTargetTest.php
+++ b/tests/Doctrine/Tests/Annotations/Metadata/AnnotationTargetTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Annotations\Metadata;
+
+use Doctrine\Annotations\Metadata\AnnotationTarget;
+use Doctrine\Annotations\Metadata\Exception\InvalidAnnotationTarget;
+use PHPUnit\Framework\TestCase;
+use function sprintf;
+
+final class AnnotationTargetTest extends TestCase
+{
+    public function testConstructor() : void
+    {
+        self::assertSame(AnnotationTarget::TARGET_ALL, (new AnnotationTarget(AnnotationTarget::TARGET_ALL))->unwrap());
+    }
+
+    public function testAllIncludesEverything() : void
+    {
+        self::assertTrue((AnnotationTarget::TARGET_ALL & AnnotationTarget::TARGET_CLASS) !== 0, 'class in all');
+        self::assertTrue((AnnotationTarget::TARGET_ALL & AnnotationTarget::TARGET_METHOD) !== 0, 'method in all');
+        self::assertTrue((AnnotationTarget::TARGET_ALL & AnnotationTarget::TARGET_PROPERTY) !== 0, 'property in all');
+        self::assertTrue((AnnotationTarget::TARGET_ALL & AnnotationTarget::TARGET_ANNOTATION) !== 0, 'annotation in all');
+    }
+
+    public function testStaticFactories() : void
+    {
+        self::assertSame(AnnotationTarget::TARGET_CLASS, AnnotationTarget::class()->unwrap());
+        self::assertSame(AnnotationTarget::TARGET_METHOD, AnnotationTarget::method()->unwrap());
+        self::assertSame(AnnotationTarget::TARGET_PROPERTY, AnnotationTarget::property()->unwrap());
+        self::assertSame(AnnotationTarget::TARGET_ANNOTATION, AnnotationTarget::annotation()->unwrap());
+        self::assertSame(AnnotationTarget::TARGET_ALL, AnnotationTarget::all()->unwrap());
+    }
+
+    /**
+     * @dataProvider accessorsProvider()
+     */
+    public function testAccessors(AnnotationTarget $target, int $raw) : void
+    {
+        self::assertSame(($raw & AnnotationTarget::TARGET_CLASS) !== 0, $target->targetsClass());
+        self::assertSame(($raw & AnnotationTarget::TARGET_METHOD) !== 0, $target->targetsMethod());
+        self::assertSame(($raw & AnnotationTarget::TARGET_PROPERTY) !== 0, $target->targetsProperty());
+        self::assertSame(($raw & AnnotationTarget::TARGET_ANNOTATION) !== 0, $target->targetsAnnotation());
+    }
+
+    /**
+     * @dataProvider describeProvider()
+     */
+    public function testDescribe(AnnotationTarget $target, string $described) : void
+    {
+        self::assertSame($described, $target->describe());
+    }
+
+    /**
+     * @dataProvider invalidTargetsProvider()
+     */
+    public function testInvalidTargetBitmask(int $target) : void
+    {
+        $this->expectException(InvalidAnnotationTarget::class);
+        $this->expectExceptionMessage(sprintf('Annotation target "%d" is not valid bitmask of allowed targets.', $target));
+
+        new AnnotationTarget($target);
+    }
+
+    /**
+     * @return (AnnotationTarget|int)[][]
+     */
+    public function accessorsProvider() : iterable
+    {
+        yield [AnnotationTarget::class(), AnnotationTarget::TARGET_CLASS];
+        yield [AnnotationTarget::method(), AnnotationTarget::TARGET_METHOD];
+        yield [AnnotationTarget::property(), AnnotationTarget::TARGET_PROPERTY];
+        yield [AnnotationTarget::annotation(), AnnotationTarget::TARGET_ANNOTATION];
+        yield [AnnotationTarget::all(), AnnotationTarget::TARGET_ALL];
+    }
+
+    /**
+     * @return (AnnotationTarget|int)[][]
+     */
+    public function describeProvider() : iterable
+    {
+        yield [AnnotationTarget::class(), 'CLASS'];
+        yield [AnnotationTarget::method(), 'METHOD'];
+        yield [AnnotationTarget::property(), 'PROPERTY'];
+        yield [AnnotationTarget::annotation(), 'ANNOTATION'];
+        yield [AnnotationTarget::all(), 'ALL'];
+        yield [
+            new AnnotationTarget(AnnotationTarget::TARGET_CLASS | AnnotationTarget::TARGET_ANNOTATION),
+            'CLASS, ANNOTATION',
+        ];
+    }
+
+    /**
+     * @return int[][]
+     */
+    public function invalidTargetsProvider() : iterable
+    {
+        yield [-1];
+        yield [AnnotationTarget::TARGET_ALL + 1];
+    }
+}

--- a/tests/Doctrine/Tests/Annotations/Metadata/Builder/AnnotationMetadataBuilderTest.php
+++ b/tests/Doctrine/Tests/Annotations/Metadata/Builder/AnnotationMetadataBuilderTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Annotations\Metadata\Builder;
+
+use Doctrine\Annotations\Metadata\AnnotationTarget;
+use Doctrine\Annotations\Metadata\Builder\AnnotationMetadataBuilder;
+use Doctrine\Annotations\Metadata\PropertyMetadata;
+use PHPUnit\Framework\TestCase;
+
+final class AnnotationMetadataBuilderTest extends TestCase
+{
+    public function testDefaults() : void
+    {
+        $metadata = (new AnnotationMetadataBuilder('Foo'))->build();
+
+        self::assertSame('Foo', $metadata->getName());
+        self::assertSame(AnnotationTarget::TARGET_ALL, $metadata->getTarget()->unwrap());
+        self::assertFalse($metadata->usesConstructor());
+        self::assertSame([], $metadata->getProperties());
+        self::assertNull($metadata->getDefaultProperty());
+    }
+
+    public function testBuilding() : void
+    {
+        $propertyA = new PropertyMetadata('a', ['type' => 'string'], true, true);
+        $propertyB = new PropertyMetadata('b', ['type' => 'boolean']);
+
+        $metadata = (new AnnotationMetadataBuilder('Foo'))
+            ->withTarget(AnnotationTarget::class())
+            ->withUsingConstructor()
+            ->withProperty($propertyA)
+            ->withProperty($propertyB)
+            ->build();
+
+        self::assertSame('Foo', $metadata->getName());
+        self::assertSame(AnnotationTarget::TARGET_CLASS, $metadata->getTarget()->unwrap());
+        self::assertTrue($metadata->usesConstructor());
+        self::assertSame(['a' => $propertyA, 'b' => $propertyB], $metadata->getProperties());
+        self::assertSame($propertyA, $metadata->getDefaultProperty());
+    }
+}

--- a/tests/Doctrine/Tests/Annotations/Metadata/Builder/AnnotationMetadataTest.php
+++ b/tests/Doctrine/Tests/Annotations/Metadata/Builder/AnnotationMetadataTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Annotations\Metadata\Builder;
+
+use Doctrine\Annotations\Metadata\AnnotationMetadata;
+use Doctrine\Annotations\Metadata\AnnotationTarget;
+use Doctrine\Annotations\Metadata\Exception\TooManyDefaultProperties;
+use Doctrine\Annotations\Metadata\PropertyMetadata;
+use PHPUnit\Framework\TestCase;
+
+final class AnnotationMetadataTest extends TestCase
+{
+    public function testMultipleDefaultProperties() : void
+    {
+        $this->expectException(TooManyDefaultProperties::class);
+        $this->expectExceptionMessage(
+            'The annotation "Foo" can only have at most one default property, currently has 2: "a", "b".'
+        );
+
+        new AnnotationMetadata(
+            'Foo',
+            AnnotationTarget::all(),
+            false,
+            new PropertyMetadata(
+                'a',
+                ['type' => 'string'],
+                true,
+                true
+            ),
+            new PropertyMetadata(
+                'b',
+                ['type' => 'string'],
+                true,
+                true
+            )
+        );
+    }
+}

--- a/tests/Doctrine/Tests/Annotations/Metadata/Builder/PropertyMetadataBuilderTest.php
+++ b/tests/Doctrine/Tests/Annotations/Metadata/Builder/PropertyMetadataBuilderTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Annotations\Metadata\Builder;
+
+use Doctrine\Annotations\Metadata\Builder\PropertyMetadataBuilder;
+use PHPUnit\Framework\TestCase;
+
+final class PropertyMetadataBuilderTest extends TestCase
+{
+    public function testDefaults() : void
+    {
+        $metadata = (new PropertyMetadataBuilder('foo'))->build();
+
+        self::assertSame('foo', $metadata->getName());
+        self::assertFalse($metadata->isRequired());
+        self::assertNull($metadata->getType());
+        self::assertFalse($metadata->isDefault());
+        self::assertNull($metadata->getEnum());
+    }
+
+    public function testBuilding() : void
+    {
+        $metadata = (new PropertyMetadataBuilder('foo'))
+            ->withBeingDefault()
+            ->withBeingRequired()
+            ->withType(['type' => 'string'])
+            ->withEnum(['value' => [1, 2, 3], 'literal' => '1, 2, 3'])
+            ->build();
+
+        self::assertSame('foo', $metadata->getName());
+        self::assertTrue($metadata->isRequired());
+        self::assertSame(['type' => 'string'], $metadata->getType());
+        self::assertTrue($metadata->isDefault());
+        self::assertSame(['value' => [1, 2, 3], 'literal' => '1, 2, 3'], $metadata->getEnum());
+    }
+}

--- a/tests/Doctrine/Tests/Annotations/Metadata/TransientMetadataCollectionTest.php
+++ b/tests/Doctrine/Tests/Annotations/Metadata/TransientMetadataCollectionTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Annotations\Metadata;
+
+use Doctrine\Annotations\Metadata\AnnotationMetadata;
+use Doctrine\Annotations\Metadata\AnnotationTarget;
+use Doctrine\Annotations\Metadata\Exception\MetadataAlreadyExists;
+use Doctrine\Annotations\Metadata\Exception\MetadataDoesNotExist;
+use Doctrine\Annotations\Metadata\TransientMetadataCollection;
+use PHPUnit\Framework\TestCase;
+use function iterator_to_array;
+
+final class TransientMetadataCollectionTest extends TestCase
+{
+    public function testCollectionInterface() : void
+    {
+        $foo = $this->createDummyMetadata('Foo');
+        $bar = $this->createDummyMetadata('Bar');
+        $baz = $this->createDummyMetadata('Baz');
+
+        $collection = new TransientMetadataCollection();
+
+        self::assertCount(0, $collection);
+        self::assertFalse($collection->has('Foo'));
+        self::assertFalse($collection->has('Bar'));
+        self::assertFalse($collection->has('Baz'));
+        self::assertSame([], iterator_to_array($collection));
+
+        $collection->add($foo, $bar);
+
+        self::assertCount(2, $collection);
+        self::assertTrue($collection->has('Foo'));
+        self::assertSame($foo, $collection->get('Foo'));
+        self::assertTrue($collection->has('Bar'));
+        self::assertSame($bar, $collection->get('Bar'));
+        self::assertSame([$foo, $bar], iterator_to_array($collection));
+
+        $collection->add($baz);
+
+        self::assertCount(3, $collection);
+        self::assertTrue($collection->has('Baz'));
+        self::assertSame($baz, $collection->get('Baz'));
+        self::assertSame([$foo, $bar, $baz], iterator_to_array($collection));
+    }
+
+    public function testInclude() : void
+    {
+        $foo = $this->createDummyMetadata('Foo');
+        $bar = $this->createDummyMetadata('Bar');
+        $baz = $this->createDummyMetadata('Baz');
+
+        $collection = new TransientMetadataCollection($foo);
+        $collection->include(new TransientMetadataCollection($bar, $baz));
+
+        self::assertCount(3, $collection);
+        self::assertSame([$foo, $bar, $baz], iterator_to_array($collection));
+    }
+
+    public function testMetadataInConstructor() : void
+    {
+        self::assertCount(
+            2,
+            new TransientMetadataCollection(
+                $this->createDummyMetadata('A'),
+                $this->createDummyMetadata('B')
+            )
+        );
+    }
+
+    public function testDuplicateMetadata() : void
+    {
+        $this->expectException(MetadataAlreadyExists::class);
+        $this->expectExceptionMessage('Metadata for annotation "Foo" already exists.');
+
+        new TransientMetadataCollection(
+            $this->createDummyMetadata('Foo'),
+            $this->createDummyMetadata('Bar'),
+            $this->createDummyMetadata('Foo')
+        );
+    }
+
+    public function testGettingNonexistentMetadata() : void
+    {
+        $collection = new TransientMetadataCollection();
+
+        $this->expectException(MetadataDoesNotExist::class);
+        $this->expectExceptionMessage('Metadata for annotation "Foo" does not exist.');
+
+        $collection->get('Foo');
+    }
+
+    private function createDummyMetadata(string $name) : AnnotationMetadata
+    {
+        return new AnnotationMetadata($name, AnnotationTarget::all(), false);
+    }
+}


### PR DESCRIPTION
Replace nested untyped metadata arrays structure inside DocParser by proper object metadata classes with builder.
This idea is somewhat inspired by #75 but this approach uses separate PropertyMetadata instead of plain untyped array as well as being more strictly typed.

Metadata will later be used by the new parser as well.
This is just an internals refactoring so it's not a BC break. No existing tests were touched.