### PR TITLE
Skip parsing annotations containing dashes, such as `@Foo-bar`, or `@Foo-`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ cache:
 php:
   - 7.1
   - 7.2
+  - 7.3
+  - 7.4snapshot
   - nightly
 
 matrix:
@@ -23,3 +25,8 @@ before_script:
 script:
     - vendor/bin/phpunit
     - if [[ $PHPSTAN = 1 ]]; then vendor/bin/phpstan analyse -c phpstan.neon -l 3 lib tests; fi
+
+jobs:
+  allow_failures:
+    - php: 7.4snapshot
+    - php: nightly

--- a/lib/Doctrine/Common/Annotations/DocLexer.php
+++ b/lib/Doctrine/Common/Annotations/DocLexer.php
@@ -79,7 +79,7 @@ final class DocLexer extends AbstractLexer
     );
 
     /**
-     * Whether the token next token starts immediately, of if there were
+     * Whether the next token starts immediately, or if there were
      * non-captured symbols before that
      */
     public function nextTokenIsAdjacent() : bool

--- a/lib/Doctrine/Common/Annotations/DocLexer.php
+++ b/lib/Doctrine/Common/Annotations/DocLexer.php
@@ -51,6 +51,7 @@ final class DocLexer extends AbstractLexer
     const T_TRUE                = 110;
     const T_NULL                = 111;
     const T_COLON               = 112;
+    const T_MINUS               = 113;
 
     /**
      * @var array
@@ -64,6 +65,7 @@ final class DocLexer extends AbstractLexer
         '}'  => self::T_CLOSE_CURLY_BRACES,
         '='  => self::T_EQUALS,
         ':'  => self::T_COLON,
+        '-'  => self::T_MINUS,
         '\\' => self::T_NAMESPACE_SEPARATOR
     );
 

--- a/lib/Doctrine/Common/Annotations/DocLexer.php
+++ b/lib/Doctrine/Common/Annotations/DocLexer.php
@@ -79,6 +79,17 @@ final class DocLexer extends AbstractLexer
     );
 
     /**
+     * Whether the token next token starts immediately, of if there were
+     * non-captured symbols before that
+     */
+    public function nextTokenIsAdjacent() : bool
+    {
+        return $this->token === null
+            || ($this->lookahead !== null
+                && ($this->lookahead['position'] - $this->token['position']) === strlen($this->token['value']));
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected function getCatchablePatterns()

--- a/lib/Doctrine/Common/Annotations/DocParser.php
+++ b/lib/Doctrine/Common/Annotations/DocParser.php
@@ -686,6 +686,13 @@ final class DocParser
         // check if we have an annotation
         $name = $this->Identifier();
 
+        if ($this->lexer->isNextToken(DocLexer::T_MINUS)
+            && $this->lexer->nextTokenIsAdjacent()
+        ) {
+            // Annotations with dashes, such as "@foo-" or "@foo-bar", are to be discarded
+            return false;
+        }
+
         // only process names which are not fully qualified, yet
         // fully qualified names must start with a \
         $originalName = $name;

--- a/tests/Doctrine/Tests/Common/Annotations/AbstractReaderTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/AbstractReaderTest.php
@@ -445,6 +445,30 @@ abstract class AbstractReaderTest extends TestCase
         self::assertEmpty($reader->getClassAnnotations($ref));
     }
 
+    public function testWillSkipAnnotationsContainingDashes()
+    {
+        self::assertEmpty(
+            $this
+                ->getReader()
+                ->getClassAnnotations(new \ReflectionClass(
+                    Fixtures\ClassWithInvalidAnnotationContainingDashes::class
+                ))
+        );
+    }
+
+    public function testWillFailOnAnnotationConstantReferenceContainingDashes()
+    {
+        $reader     = $this->getReader();
+        $reflection = new \ReflectionClass(Fixtures\ClassWithAnnotationConstantReferenceWithDashes::class);
+
+        $this->expectExceptionMessage(
+            '[Syntax Error] Expected Doctrine\Common\Annotations\DocLexer::T_CLOSE_PARENTHESIS, got \'-\' at'
+            . ' position 14 in class ' . Fixtures\ClassWithAnnotationConstantReferenceWithDashes::class . '.'
+        );
+
+        $reader->getClassAnnotations($reflection);
+    }
+
     /**
      * @return AnnotationReader
      */

--- a/tests/Doctrine/Tests/Common/Annotations/DocLexerTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/DocLexerTest.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
 
 class DocLexerTest extends TestCase
 {
-    public function testMarkerAnnotation()
+    public function testMarkerAnnotation() : void
     {
         $lexer = new DocLexer;
 
@@ -26,7 +26,7 @@ class DocLexerTest extends TestCase
         self::assertFalse($lexer->moveNext());
     }
 
-    public function testScannerTokenizesDocBlockWhitConstants()
+    public function testScannerTokenizesDocBlockWhitConstants() : void
     {
         $lexer      = new DocLexer();
         $docblock   = '@AnnotationWithConstants(PHP_EOL, ClassWithConstants::SOME_VALUE, ClassWithConstants::CONSTANT_, ClassWithConstants::CONST_ANT3, \Doctrine\Tests\Common\Annotations\Fixtures\InterfaceWithConstants::SOME_VALUE)';
@@ -114,7 +114,7 @@ class DocLexerTest extends TestCase
     }
 
 
-    public function testScannerTokenizesDocBlockWhitInvalidIdentifier()
+    public function testScannerTokenizesDocBlockWhitInvalidIdentifier() : void
     {
         $lexer      = new DocLexer();
         $docblock   = '@Foo\3.42';
@@ -158,7 +158,7 @@ class DocLexerTest extends TestCase
     /**
      * @group 44
      */
-    public function testWithinDoubleQuotesVeryVeryLongStringWillNotOverflowPregSplitStackLimit()
+    public function testWithinDoubleQuotesVeryVeryLongStringWillNotOverflowPregSplitStackLimit() : void
     {
         $lexer = new DocLexer();
 
@@ -170,7 +170,7 @@ class DocLexerTest extends TestCase
     /**
      * @group 44
      */
-    public function testRecognizesDoubleQuotesEscapeSequence()
+    public function testRecognizesDoubleQuotesEscapeSequence() : void
     {
         $lexer    = new DocLexer();
         $docblock = '@Foo("""' . "\n" . '""")';
@@ -216,7 +216,7 @@ class DocLexerTest extends TestCase
         self::assertFalse($lexer->moveNext());
     }
 
-    public function testDoesNotRecognizeFullAnnotationWithDashInIt()
+    public function testDoesNotRecognizeFullAnnotationWithDashInIt() : void
     {
         $this->expectDocblockTokens(
             '@foo-bar--',
@@ -255,7 +255,7 @@ class DocLexerTest extends TestCase
         );
     }
 
-    public function testRecognizesNegativeNumbers()
+    public function testRecognizesNegativeNumbers() : void
     {
         $this->expectDocblockTokens(
             '-12.34 -56',
@@ -274,8 +274,7 @@ class DocLexerTest extends TestCase
         );
     }
 
-    /** @return void */
-    private function expectDocblockTokens(string $docBlock, array $expectedTokens)
+    private function expectDocblockTokens(string $docBlock, array $expectedTokens) : void
     {
         $lexer    = new DocLexer();
         $lexer->setInput($docBlock);
@@ -295,7 +294,7 @@ class DocLexerTest extends TestCase
         self::assertEquals($expectedTokens, $actualTokens);
     }
 
-    public function testTokenAdjacency()
+    public function testTokenAdjacency() : void
     {
         $lexer    = new DocLexer();
 

--- a/tests/Doctrine/Tests/Common/Annotations/DocLexerTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/DocLexerTest.php
@@ -215,4 +215,83 @@ class DocLexerTest extends TestCase
 
         self::assertFalse($lexer->moveNext());
     }
+
+    public function testDoesNotRecognizeFullAnnotationWithDashInIt()
+    {
+        $this->expectDocblockTokens(
+            '@foo-bar--',
+            [
+                [
+                    'value'     => '@',
+                    'position'  => 0,
+                    'type'      => DocLexer::T_AT,
+                ],
+                [
+                    'value'     => 'foo',
+                    'position'  => 1,
+                    'type'      => DocLexer::T_IDENTIFIER,
+                ],
+                [
+                    'value'     => '-',
+                    'position'  => 4,
+                    'type'      => DocLexer::T_MINUS,
+                ],
+                [
+                    'value'     => 'bar',
+                    'position'  => 5,
+                    'type'      => DocLexer::T_IDENTIFIER,
+                ],
+                [
+                    'value'     => '-',
+                    'position'  => 8,
+                    'type'      => DocLexer::T_MINUS,
+                ],
+                [
+                    'value'     => '-',
+                    'position'  => 9,
+                    'type'      => DocLexer::T_MINUS,
+                ],
+            ]
+        );
+    }
+
+    public function testRecognizesNegativeNumbers()
+    {
+        $this->expectDocblockTokens(
+            '-12.34 -56',
+            [
+                [
+                    'value'     => '-12.34',
+                    'position'  => 0,
+                    'type'      => DocLexer::T_FLOAT,
+                ],
+                [
+                    'value'     => '-56',
+                    'position'  => 7,
+                    'type'      => DocLexer::T_INTEGER,
+                ]
+            ]
+        );
+    }
+
+    /** @return void */
+    private function expectDocblockTokens(string $docBlock, array $expectedTokens)
+    {
+        $lexer    = new DocLexer();
+        $lexer->setInput($docBlock);
+
+        $actualTokens = [];
+
+        while ($lexer->moveNext()) {
+            $lookahead = $lexer->lookahead;
+
+            $actualTokens[] = [
+                'value' => $lookahead['value'],
+                'type' => $lookahead['type'],
+                'position' => $lookahead['position'],
+            ];
+        }
+
+        self::assertEquals($expectedTokens, $actualTokens);
+    }
 }

--- a/tests/Doctrine/Tests/Common/Annotations/DocLexerTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/DocLexerTest.php
@@ -294,4 +294,20 @@ class DocLexerTest extends TestCase
 
         self::assertEquals($expectedTokens, $actualTokens);
     }
+
+    public function testTokenAdjacency()
+    {
+        $lexer    = new DocLexer();
+
+        $lexer->setInput('-- -');
+
+        self::assertTrue($lexer->nextTokenIsAdjacent());
+        self::assertTrue($lexer->moveNext());
+        self::assertTrue($lexer->nextTokenIsAdjacent());
+        self::assertTrue($lexer->moveNext());
+        self::assertTrue($lexer->nextTokenIsAdjacent());
+        self::assertTrue($lexer->moveNext());
+        self::assertFalse($lexer->nextTokenIsAdjacent());
+        self::assertFalse($lexer->moveNext());
+    }
 }

--- a/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
@@ -852,7 +852,7 @@ DOCBLOCK;
             '@Doctrine\Tests\Common\Annotations\Fixtures\AnnotationWithConstants(Doctrine\Tests\Common\Annotations\Fixtures\AnnotationWithConstants::class)',
             AnnotationWithConstants::class
         );
-        return $provider;
+        return array_combine(array_column($provider, 0), $provider);
     }
 
     /**
@@ -1404,6 +1404,23 @@ DOCBLOCK;
 
         self::assertCount(1, $result);
 
+    }
+
+    public function testWillNotParseAnnotationSucceededByAnImmediateDash()
+    {
+        $parser = $this->createTestParser();
+
+        self::assertEmpty($parser->parse('@SomeAnnotationClassNameWithoutConstructorAndProperties-'));
+    }
+
+    public function testWillParseAnnotationSucceededByANonImmediateDash()
+    {
+        $result = $this
+            ->createTestParser()
+            ->parse('@SomeAnnotationClassNameWithoutConstructorAndProperties -');
+
+        self::assertCount(1, $result);
+        self::assertInstanceOf(SomeAnnotationClassNameWithoutConstructorAndProperties::class, $result[0]);
     }
 }
 

--- a/tests/Doctrine/Tests/Common/Annotations/Fixtures/ClassWithAnnotationConstantReferenceWithDashes.php
+++ b/tests/Doctrine/Tests/Common/Annotations/Fixtures/ClassWithAnnotationConstantReferenceWithDashes.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Doctrine\Tests\Common\Annotations\Fixtures;
+
+use Doctrine\Tests\Common\Annotations\Fixtures\Annotation\Route;
+
+/** @Route(@AValid-constant::REFERENCE) */
+class ClassWithAnnotationConstantReferenceWithDashes
+{
+}

--- a/tests/Doctrine/Tests/Common/Annotations/Fixtures/ClassWithInvalidAnnotationContainingDashes.php
+++ b/tests/Doctrine/Tests/Common/Annotations/Fixtures/ClassWithInvalidAnnotationContainingDashes.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Doctrine\Tests\Common\Annotations\Fixtures;
+
+/**
+ * @please-do-not-parse-me
+ * @AlsoDoNot\Parse-me
+ */
+class ClassWithInvalidAnnotationContainingDashes
+{
+}


### PR DESCRIPTION
Most likely fixes https://github.com/doctrine/collections/issues/180