### PR TITLE
Remove imprecise `T_IDENTIFIER` capture groups, leading to simpler token sequences

### DIFF
--- a/lib/Doctrine/Common/Annotations/DocLexer.php
+++ b/lib/Doctrine/Common/Annotations/DocLexer.php
@@ -101,8 +101,6 @@ final class DocLexer extends AbstractLexer
      */
     protected function getType(&$value)
     {
-        $type = self::T_NONE;
-
         if ($value[0] === '"') {
             $value = str_replace('""', '"', substr($value, 1, strlen($value) - 2));
 
@@ -129,6 +127,6 @@ final class DocLexer extends AbstractLexer
                 ? self::T_FLOAT : self::T_INTEGER;
         }
 
-        return $type;
+        return self::T_NONE;
     }
 }

--- a/lib/Doctrine/Common/Annotations/DocLexer.php
+++ b/lib/Doctrine/Common/Annotations/DocLexer.php
@@ -45,6 +45,7 @@ final class DocLexer extends AbstractLexer
     const T_COMMA               = 104;
     const T_EQUALS              = 105;
     const T_FALSE               = 106;
+    /** @deprecated if you are looking for an identifier, use T_IDENTIFIER directly instead */
     const T_NAMESPACE_SEPARATOR = 107;
     const T_OPEN_CURLY_BRACES   = 108;
     const T_OPEN_PARENTHESIS    = 109;
@@ -82,8 +83,13 @@ final class DocLexer extends AbstractLexer
     protected function getCatchablePatterns()
     {
         return [
-            '[a-z_\\\][a-z0-9_\:\\\]*[a-z_][a-z0-9_]*',
+            // Identifier
+            '[\\\\]{0,1}[a-z_][a-z0-9_]*(?:\\\\[a-z_][a-z0-9_]*)*(?:::[a-z_][a-z0-9_]*)*',
+
+            // Number
             '(?:[+-]?[0-9]+(?:[\.][0-9]+)*)(?:[eE][+-]?[0-9]+)?',
+
+            // String enclosed in ""
             '"(?:""|[^"])*+"',
         ];
     }
@@ -93,7 +99,16 @@ final class DocLexer extends AbstractLexer
      */
     protected function getNonCatchablePatterns()
     {
-        return ['\s+', '\*+', '(.)'];
+        return [
+            // We ignore whitespace
+            '\s+',
+
+            // We ignore * (used to start docBlock comment lines)
+            '\*+',
+
+            // Any other character that wasn't ignored before is to be collected and trashed
+            '(.)'
+        ];
     }
 
     /**

--- a/lib/Doctrine/Common/Annotations/DocParser.php
+++ b/lib/Doctrine/Common/Annotations/DocParser.php
@@ -651,7 +651,7 @@ final class DocParser
             // make sure the @ is followed by either a namespace separator, or
             // an identifier token
             if ((null === $peek = $this->lexer->glimpse())
-                || (DocLexer::T_NAMESPACE_SEPARATOR !== $peek['type'] && !in_array($peek['type'], self::$classIdentifiers, true))
+                || !in_array($peek['type'], self::$classIdentifiers, true)
                 || $peek['position'] !== $this->lexer->lookahead['position'] + 1) {
                 $this->lexer->moveNext();
                 continue;
@@ -988,18 +988,7 @@ final class DocParser
 
         $this->lexer->moveNext();
 
-        $className = $this->lexer->token['value'];
-
-        while ($this->lexer->lookahead['position'] === ($this->lexer->token['position'] + strlen($this->lexer->token['value']))
-                && $this->lexer->isNextToken(DocLexer::T_NAMESPACE_SEPARATOR)) {
-
-            $this->match(DocLexer::T_NAMESPACE_SEPARATOR);
-            $this->matchAny(self::$classIdentifiers);
-
-            $className .= '\\' . $this->lexer->token['value'];
-        }
-
-        return $className;
+        return $this->lexer->token['value'];
     }
 
     /**

--- a/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
@@ -1258,16 +1258,6 @@ DOCBLOCK;
         $this->createTestParser()->parse($docblock, 'some class');
     }
 
-    /**
-     * @expectedException \Doctrine\Common\Annotations\AnnotationException
-     * @expectedExceptionMessage [Syntax Error] Expected Doctrine\Common\Annotations\DocLexer::T_IDENTIFIER or Doctrine\Common\Annotations\DocLexer::T_TRUE or Doctrine\Common\Annotations\DocLexer::T_FALSE or Doctrine\Common\Annotations\DocLexer::T_NULL, got '3.42' at position 5.
-     */
-    public function testInvalidIdentifierInAnnotation()
-    {
-        $parser = $this->createTestParser();
-        $parser->parse('@Foo\3.42');
-    }
-
     public function testTrailingCommaIsAllowed()
     {
         $parser = $this->createTestParser();


### PR DESCRIPTION
Note: I just need a review - will forward-port after that.

Discovered while working on #257 

A `T_IDENTIFIER` represents:

 * a constant
 * a function name
 * a function name prefixed with `\`
 * a class name
 * a class name prefixed with `\`
 * a class constant
 * a class constant, with class name prefixed with `\`

The current capturing regular expression is too simplistic, and it
leads to edge cases where `Foo\42.5` are captured as separate tokens.

In this patch, we deprecate `DocLexer::T_NAMESPACE_SEPARATOR` (which
shouldn't be looked up directly anymore), and tell the parser to work
with wider `T_IDENTIFIER` tokens instead.

Note that a test is also being removed. That is intentional, since the
test verifies a parser issue when parsing `@Foo\3.42`:
 
 * previously, the tokens would be `[@ Foo\3.42]`
 * now they are `[@, Foo, \, 3.42]`

This also means that the above will be parsed as `@Foo`.