### PR TITLE
Add Constants Support

### DIFF
--- a/lib/Doctrine/Common/Annotations/Annotation/Target.php
+++ b/lib/Doctrine/Common/Annotations/Annotation/Target.php
@@ -38,7 +38,6 @@ final class Target
         'FUNCTION'   => self::TARGET_FUNCTION,
         'ANNOTATION' => self::TARGET_ANNOTATION,
         'CONSTANT'   => self::TARGET_CONSTANT,
-        'CONST'      => self::TARGET_CONSTANT,
     ];
 
     /** @phpstan-var list<string> */

--- a/lib/Doctrine/Common/Annotations/Annotation/Target.php
+++ b/lib/Doctrine/Common/Annotations/Annotation/Target.php
@@ -26,7 +26,8 @@ final class Target
     public const TARGET_PROPERTY   = 4;
     public const TARGET_ANNOTATION = 8;
     public const TARGET_FUNCTION   = 16;
-    public const TARGET_ALL        = 31;
+    public const TARGET_CONSTANT   = 32;
+    public const TARGET_ALL        = 63;
 
     /** @var array<string, int> */
     private static $map = [
@@ -36,6 +37,8 @@ final class Target
         'PROPERTY'   => self::TARGET_PROPERTY,
         'FUNCTION'   => self::TARGET_FUNCTION,
         'ANNOTATION' => self::TARGET_ANNOTATION,
+        'CONSTANT'   => self::TARGET_CONSTANT,
+        'CONST'      => self::TARGET_CONSTANT,
     ];
 
     /** @phpstan-var list<string> */

--- a/lib/Doctrine/Common/Annotations/AnnotationReader.php
+++ b/lib/Doctrine/Common/Annotations/AnnotationReader.php
@@ -229,7 +229,7 @@ class AnnotationReader implements Reader, ReaderWithConstantsAnnotations
     /**
      * {@inheritDoc}
      */
-    public function getConstantAnnotations(\ReflectionClassConstant $constant)
+    public function getConstantAnnotations(\ReflectionClassConstant $constant): array
     {
         $class   = $constant->getDeclaringClass();
         $context = 'constant ' . $class->getName() . "::" . $constant->getName();
@@ -386,12 +386,8 @@ class AnnotationReader implements Reader, ReaderWithConstantsAnnotations
 
     /**
      * Retrieves imports for constants.
-     *
-     * @param \ReflectionClassConstant $constant
-     *
-     * @return array
      */
-    private function getConstantImports(\ReflectionClassConstant $constant)
+    private function getConstantImports(\ReflectionClassConstant $constant): array
     {
         $class = $constant->getDeclaringClass();
         $classImports = $this->getImports($class);

--- a/lib/Doctrine/Common/Annotations/AnnotationReader.php
+++ b/lib/Doctrine/Common/Annotations/AnnotationReader.php
@@ -17,7 +17,7 @@ use function ini_get;
 /**
  * A reader for docblock annotations.
  */
-class AnnotationReader implements Reader
+class AnnotationReader implements Reader, ReaderWithConstantsAnnotations
 {
     /**
      * Global map for imports.

--- a/lib/Doctrine/Common/Annotations/CachedReader.php
+++ b/lib/Doctrine/Common/Annotations/CachedReader.php
@@ -17,7 +17,7 @@ use function time;
 /**
  * A cache aware annotation reader.
  */
-final class CachedReader implements Reader
+final class CachedReader implements Reader, ReaderWithConstantsAnnotations
 {
     /** @var Reader */
     private $delegate;

--- a/lib/Doctrine/Common/Annotations/CachedReader.php
+++ b/lib/Doctrine/Common/Annotations/CachedReader.php
@@ -116,7 +116,7 @@ final class CachedReader implements Reader, ReaderWithConstantsAnnotations
     /**
      * {@inheritDoc}
      */
-    public function getConstantAnnotations(\ReflectionClassConstant $constant)
+    public function getConstantAnnotations(\ReflectionClassConstant $constant): array
     {
         $class = $constant->getDeclaringClass();
         $cacheKey = $class->getName().'::'.$constant->getName();

--- a/lib/Doctrine/Common/Annotations/FileCacheReader.php
+++ b/lib/Doctrine/Common/Annotations/FileCacheReader.php
@@ -169,7 +169,7 @@ class FileCacheReader implements Reader, ReaderWithConstantsAnnotations
     /**
      * {@inheritDoc}
      */
-    public function getConstantAnnotations(\ReflectionClassConstant $constant)
+    public function getConstantAnnotations(\ReflectionClassConstant $constant): array
     {
         $class = $constant->getDeclaringClass();
         if ( ! isset($this->classNameHashes[$class->name])) {

--- a/lib/Doctrine/Common/Annotations/FileCacheReader.php
+++ b/lib/Doctrine/Common/Annotations/FileCacheReader.php
@@ -35,7 +35,7 @@ use function var_export;
  *             in version 2.0.0 of doctrine/annotations. Please use the
  *             {@see \Doctrine\Common\Annotations\CachedReader} instead.
  */
-class FileCacheReader implements Reader
+class FileCacheReader implements Reader, ReaderWithConstantsAnnotations
 {
     /** @var Reader */
     private $reader;

--- a/lib/Doctrine/Common/Annotations/IndexedReader.php
+++ b/lib/Doctrine/Common/Annotations/IndexedReader.php
@@ -12,7 +12,7 @@ use function get_class;
 /**
  * Allows the reader to be used in-place of Doctrine's reader.
  */
-class IndexedReader implements Reader
+class IndexedReader implements Reader, ReaderWithConstantsAnnotations
 {
     /** @var Reader */
     private $delegate;

--- a/lib/Doctrine/Common/Annotations/IndexedReader.php
+++ b/lib/Doctrine/Common/Annotations/IndexedReader.php
@@ -86,6 +86,27 @@ class IndexedReader implements Reader, ReaderWithConstantsAnnotations
     }
 
     /**
+     * {@inheritDoc}
+     */
+    public function getConstantAnnotations(\ReflectionClassConstant $constant): array
+    {
+        $annotations = [];
+        foreach ($this->delegate->getConstantAnnotations($constant) as $annot) {
+            $annotations[get_class($annot)] = $annot;
+        }
+
+        return $annotations;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getConstantAnnotation(\ReflectionClassConstant $constant, $annotation)
+    {
+        return $this->delegate->getConstantAnnotation($constant, $annotation);
+    }
+
+    /**
      * Proxies all methods to the delegate.
      *
      * @param string  $method

--- a/lib/Doctrine/Common/Annotations/ReaderWithConstantsAnnotations.php
+++ b/lib/Doctrine/Common/Annotations/ReaderWithConstantsAnnotations.php
@@ -33,9 +33,9 @@ interface ReaderWithConstantsAnnotations extends Reader
      * @param \ReflectionClassConstant $constant The ReflectionClassConstant of the constant
      *                                           from which the annotations should be read.
      *
-     * @return array An array of Annotations.
+     * @return object[] An array of Annotations.
      */
-    function getConstantAnnotations(\ReflectionClassConstant $constant);
+    function getConstantAnnotations(\ReflectionClassConstant $constant): array;
 
     /**
      * Gets a constant annotation.

--- a/lib/Doctrine/Common/Annotations/ReaderWithConstantsAnnotations.php
+++ b/lib/Doctrine/Common/Annotations/ReaderWithConstantsAnnotations.php
@@ -1,0 +1,49 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\Common\Annotations;
+
+/**
+ * Interface for annotations readers with constant annotations support.
+ *
+ * @author Josef Kufner <josef@kufner.cz>
+ * @deprecated This interface will be merged into Reader interface and removed in version 2.0.
+ */
+interface ReaderWithConstantsAnnotations extends Reader
+{
+    /**
+     * Gets the annotations applied to a constant.
+     *
+     * @param \ReflectionClassConstant $constant The ReflectionClassConstant of the constant
+     *                                           from which the annotations should be read.
+     *
+     * @return array An array of Annotations.
+     */
+    function getConstantAnnotations(\ReflectionClassConstant $constant);
+
+    /**
+     * Gets a constant annotation.
+     *
+     * @param \ReflectionClassConstant $constant       The ReflectionClassConstant to read the annotations from.
+     * @param string                   $annotationName The name of the annotation.
+     *
+     * @return object|null The Annotation or NULL, if the requested annotation does not exist.
+     */
+    function getConstantAnnotation(\ReflectionClassConstant $constant, $annotationName);
+}

--- a/lib/Doctrine/Common/Annotations/SimpleAnnotationReader.php
+++ b/lib/Doctrine/Common/Annotations/SimpleAnnotationReader.php
@@ -14,7 +14,7 @@ use ReflectionProperty;
  *
  * @deprecated Deprecated in favour of using AnnotationReader
  */
-class SimpleAnnotationReader implements Reader
+class SimpleAnnotationReader implements Reader, ReaderWithConstantsAnnotations
 {
     /** @var DocParser */
     private $parser;

--- a/lib/Doctrine/Common/Annotations/SimpleAnnotationReader.php
+++ b/lib/Doctrine/Common/Annotations/SimpleAnnotationReader.php
@@ -73,7 +73,7 @@ class SimpleAnnotationReader implements Reader, ReaderWithConstantsAnnotations
     /**
      * {@inheritDoc}
      */
-    public function getConstantAnnotations(\ReflectionClassConstant $constant)
+    public function getConstantAnnotations(\ReflectionClassConstant $constant): array
     {
         return $this->parser->parse(
             $constant->getDocComment(),

--- a/lib/Doctrine/Common/Annotations/SimpleAnnotationReader.php
+++ b/lib/Doctrine/Common/Annotations/SimpleAnnotationReader.php
@@ -73,6 +73,14 @@ class SimpleAnnotationReader implements Reader
     /**
      * {@inheritDoc}
      */
+    public function getConstantAnnotations(\ReflectionClassConstant $constant)
+    {
+        return $this->parser->parse($constant->getDocComment(), 'constant '.$constant->getDeclaringClass()->name.'::'.$constant->getName());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function getClassAnnotation(ReflectionClass $class, $annotationName)
     {
         foreach ($this->getClassAnnotations($class) as $annot) {
@@ -104,6 +112,20 @@ class SimpleAnnotationReader implements Reader
     public function getPropertyAnnotation(ReflectionProperty $property, $annotationName)
     {
         foreach ($this->getPropertyAnnotations($property) as $annot) {
+            if ($annot instanceof $annotationName) {
+                return $annot;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getConstantAnnotation(\ReflectionClassConstant $constant, $annotationName)
+    {
+        foreach ($this->getConstantAnnotations($constant) as $annot) {
             if ($annot instanceof $annotationName) {
                 return $annot;
             }

--- a/lib/Doctrine/Common/Annotations/SimpleAnnotationReader.php
+++ b/lib/Doctrine/Common/Annotations/SimpleAnnotationReader.php
@@ -75,7 +75,10 @@ class SimpleAnnotationReader implements Reader
      */
     public function getConstantAnnotations(\ReflectionClassConstant $constant)
     {
-        return $this->parser->parse($constant->getDocComment(), 'constant '.$constant->getDeclaringClass()->name.'::'.$constant->getName());
+        return $this->parser->parse(
+            $constant->getDocComment(),
+            'constant '.$constant->getDeclaringClass()->name.'::'.$constant->getName()
+        );
     }
 
     /**

--- a/tests/Doctrine/Tests/Common/Annotations/AbstractReaderTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/AbstractReaderTest.php
@@ -45,6 +45,12 @@ abstract class AbstractReaderTest extends TestCase
         );
         self::assertEquals('hello', $annot->dummyValue);
 
+        $constant = $class->getReflectionConstant('SOME_CONSTANT');
+        $constAnnots = $reader->getConstantAnnotations($constant);
+        self::assertCount(1, $constAnnots);
+        self::assertInstanceOf($annotName, $annot = $reader->getConstantAnnotation($constant, $annotName));
+        self::assertEquals('constantHello', $annot->dummyValue);
+
         $field1Prop = $class->getProperty('field1');
         $propAnnots = $reader->getPropertyAnnotations($field1Prop);
         self::assertCount(1, $propAnnots);

--- a/tests/Doctrine/Tests/Common/Annotations/AnnotationReaderTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/AnnotationReaderTest.php
@@ -14,6 +14,7 @@ use Doctrine\Tests\Common\Annotations\Fixtures\ClassWithPHPStanGenericsAnnotatio
 use Doctrine\Tests\Common\Annotations\Fixtures\IgnoredNamespaces\AnnotatedAtClassLevel;
 use Doctrine\Tests\Common\Annotations\Fixtures\IgnoredNamespaces\AnnotatedAtMethodLevel;
 use Doctrine\Tests\Common\Annotations\Fixtures\IgnoredNamespaces\AnnotatedAtPropertyLevel;
+use Doctrine\Tests\Common\Annotations\Fixtures\IgnoredNamespaces\AnnotatedAtConstantLevel;
 use Doctrine\Tests\Common\Annotations\Fixtures\IgnoredNamespaces\AnnotatedWithAlias;
 use InvalidArgumentException;
 use LogicException;
@@ -65,6 +66,15 @@ class AnnotationReaderTest extends AbstractReaderTest
 
         $annotations = $reader->getPropertyAnnotations($ref->getProperty('traitProperty'));
         self::assertInstanceOf(Fixtures\Annotation\Autoload::class, $annotations[0]);
+    }
+
+    public function testConstantAnnotation()
+    {
+        $reader = $this->getReader();
+        $ref = new \ReflectionClass(Fixtures\ClassUsesTrait::class);
+
+        $annotations = $reader->getConstantAnnotations($ref->getReflectionConstant('SOME_CONSTANT'));
+        self::assertInstanceOf(Bar\Autoload::class, $annotations[0]);
     }
 
     public function testOmitNotRegisteredAnnotation(): void
@@ -180,6 +190,21 @@ class AnnotationReaderTest extends AbstractReaderTest
         $reader::addGlobalIgnoredNamespace('SomePropertyAnnotationNamespace');
 
         self::assertEmpty($reader->getPropertyAnnotations($ref->getProperty('property')));
+    }
+
+    /**
+     * @group 45
+     *
+     * @runInSeparateProcess
+     */
+    public function testConstantAnnotationIsIgnored()
+    {
+        $reader = $this->getReader();
+        $ref = new \ReflectionClass(AnnotatedAtConstantLevel::class);
+
+        $reader::addGlobalIgnoredNamespace('SomeConstantAnnotationNamespace');
+
+        self::assertEmpty($reader->getConstantAnnotations($ref->getReflectionConstant('SOME_CONSTANT')));
     }
 
     /**

--- a/tests/Doctrine/Tests/Common/Annotations/DummyClass.php
+++ b/tests/Doctrine/Tests/Common/Annotations/DummyClass.php
@@ -13,6 +13,13 @@ namespace Doctrine\Tests\Common\Annotations;
 class DummyClass
 {
     /**
+     * A nice constant.
+     *
+     * @DummyAnnotation(dummyValue="constantHello")
+     */
+    const SOME_CONSTANT = "foo";
+
+    /**
      * A nice property.
      *
      * @var mixed

--- a/tests/Doctrine/Tests/Common/Annotations/Fixtures/ClassUsesTrait.php
+++ b/tests/Doctrine/Tests/Common/Annotations/Fixtures/ClassUsesTrait.php
@@ -17,10 +17,17 @@ class ClassUsesTrait
     /**
      * @Autoload
      */
-    public function someMethod(): void
+    const SOME_CONSTANT = "foo";
+
+    /**
+     * @Autoload
+     */
+    public function someMethod()
     {
+
     }
 }
+
 
 namespace Doctrine\Tests\Common\Annotations\Bar;
 

--- a/tests/Doctrine/Tests/Common/Annotations/Fixtures/IgnoredNamespaces/AnnotatedAtConstantLevel.php
+++ b/tests/Doctrine/Tests/Common/Annotations/Fixtures/IgnoredNamespaces/AnnotatedAtConstantLevel.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Doctrine\Tests\Common\Annotations\Fixtures\IgnoredNamespaces;
+
+class AnnotatedAtConstantLevel
+{
+    /**
+     * @SomeConstantAnnotationNamespace\Subnamespace\Name
+     */
+    const SOME_CONSTANT = "foo";
+}


### PR DESCRIPTION
Continuation of https://github.com/doctrine/annotations/pull/226. Original commits (excl. merges) cherry-picked onto 1.7 branch.

This pull request adds complete support for constant annotations. It should be the same as property annotations support.

All tests passing.

Example:

`````php
class SomeClass {
    /**
     * @SomeAnnotation
     */
    const SOME_CONSTANT = "foo";
}

$classRefl = new ClassReflection(SomeClass::class);
$constantRefl = $classRefl->getReflectionConstant('SOME_CONSTANT');
$annotations = $annotationReader->getConstantAnnotations($constantRefl);
// $annotations == [ new SomeAnnotation() ]
`````