### PR TITLE
Trigger the standard autoloader as the last resort

### DIFF
--- a/lib/Doctrine/Common/Annotations/AnnotationRegistry.php
+++ b/lib/Doctrine/Common/Annotations/AnnotationRegistry.php
@@ -64,9 +64,7 @@ final class AnnotationRegistry
     /**
      * Registers file.
      *
-     * @deprecated this method is deprecated and will be removed in doctrine/annotations 2.0
-     *             autoloading should be deferred to the globally registered autoloader by then. For now,
-     *             use @example AnnotationRegistry::registerLoader('class_exists')
+     * @deprecated This method is deprecated and will be removed in doctrine/annotations 2.0. Annotations will be autoloaded in 2.0.
      */
     public static function registerFile(string $file) : void
     {
@@ -83,9 +81,7 @@ final class AnnotationRegistry
      * @param string            $namespace
      * @param string|array|null $dirs
      *
-     * @deprecated this method is deprecated and will be removed in doctrine/annotations 2.0
-     *             autoloading should be deferred to the globally registered autoloader by then. For now,
-     *             use @example AnnotationRegistry::registerLoader('class_exists')
+     * @deprecated This method is deprecated and will be removed in doctrine/annotations 2.0. Annotations will be autoloaded in 2.0.
      */
     public static function registerAutoloadNamespace(string $namespace, $dirs = null) : void
     {
@@ -99,9 +95,7 @@ final class AnnotationRegistry
      *
      * @param string[][]|string[]|null[] $namespaces indexed by namespace name
      *
-     * @deprecated this method is deprecated and will be removed in doctrine/annotations 2.0
-     *             autoloading should be deferred to the globally registered autoloader by then. For now,
-     *             use @example AnnotationRegistry::registerLoader('class_exists')
+     * @deprecated This method is deprecated and will be removed in doctrine/annotations 2.0. Annotations will be autoloaded in 2.0.
      */
     public static function registerAutoloadNamespaces(array $namespaces) : void
     {
@@ -114,9 +108,7 @@ final class AnnotationRegistry
      * NOTE: These class loaders HAVE to be silent when a class was not found!
      * IMPORTANT: Loaders have to return true if they loaded a class that could contain the searched annotation class.
      *
-     * @deprecated this method is deprecated and will be removed in doctrine/annotations 2.0
-     *             autoloading should be deferred to the globally registered autoloader by then. For now,
-     *             use @example AnnotationRegistry::registerLoader('class_exists')
+     * @deprecated This method is deprecated and will be removed in doctrine/annotations 2.0. Annotations will be autoloaded in 2.0.
      */
     public static function registerLoader(callable $callable) : void
     {
@@ -128,7 +120,7 @@ final class AnnotationRegistry
     /**
      * Registers an autoloading callable for annotations, if it is not already registered
      *
-     * @deprecated this method is deprecated and will be removed in doctrine/annotations 2.0
+     * @deprecated This method is deprecated and will be removed in doctrine/annotations 2.0. Annotations will be autoloaded in 2.0.
      */
     public static function registerUniqueLoader(callable $callable) : void
     {

--- a/lib/Doctrine/Common/Annotations/AnnotationRegistry.php
+++ b/lib/Doctrine/Common/Annotations/AnnotationRegistry.php
@@ -166,6 +166,10 @@ final class AnnotationRegistry
                 return true;
             }
         }
+        
+        if (self::$loaders === [] && self::$autoloadNamespaces === [] && \class_exists($class)) {
+            return true;
+        }
 
         self::$failedToAutoload[$class] = null;
 

--- a/lib/Doctrine/Common/Annotations/AnnotationRegistry.php
+++ b/lib/Doctrine/Common/Annotations/AnnotationRegistry.php
@@ -47,6 +47,13 @@ final class AnnotationRegistry
      */
     static private $failedToAutoload = [];
 
+    /**
+     * Whenever registerFile() was used. Disables use of standard autoloader.
+     *
+     * @var bool
+     */
+    static private $registerFileUsed = false;
+
     public static function reset() : void
     {
         self::$autoloadNamespaces = [];
@@ -63,6 +70,8 @@ final class AnnotationRegistry
      */
     public static function registerFile(string $file) : void
     {
+        self::$registerFileUsed = true;
+
         require_once $file;
     }
 
@@ -166,8 +175,8 @@ final class AnnotationRegistry
                 return true;
             }
         }
-        
-        if (self::$loaders === [] && self::$autoloadNamespaces === [] && \class_exists($class)) {
+
+        if (self::$loaders === [] && self::$autoloadNamespaces === [] && self::$registerFileUsed === false && \class_exists($class)) {
             return true;
         }
 

--- a/lib/Doctrine/Common/Annotations/AnnotationRegistry.php
+++ b/lib/Doctrine/Common/Annotations/AnnotationRegistry.php
@@ -59,6 +59,7 @@ final class AnnotationRegistry
         self::$autoloadNamespaces = [];
         self::$loaders            = [];
         self::$failedToAutoload   = [];
+        self::$registerFileUsed   = false;
     }
 
     /**

--- a/tests/Doctrine/Tests/Common/Annotations/AnnotationRegistryTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/AnnotationRegistryTest.php
@@ -3,6 +3,9 @@
 namespace Doctrine\Tests\Common\Annotations;
 
 use Doctrine\Common\Annotations\AnnotationRegistry;
+use Doctrine\Tests\Common\Annotations\Fixtures\Annotation\CanBeAutoLoaded;
+use Doctrine\Tests\Common\Annotations\Fixtures\Annotation\LoadedUsingRegisterFile;
+use Doctrine\Tests\Common\Annotations\Fixtures\Annotation\ShouldNeverBeLoaded;
 use PHPUnit\Framework\TestCase;
 
 class AnnotationRegistryTest extends TestCase
@@ -182,5 +185,27 @@ class AnnotationRegistryTest extends TestCase
         AnnotationRegistry::registerUniqueLoader($autoLoader);
         AnnotationRegistry::loadAnnotationClass($className);
         AnnotationRegistry::loadAnnotationClass($className);
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testClassExistsFallback() : void
+    {
+        AnnotationRegistry::reset();
+
+        self::assertTrue(AnnotationRegistry::loadAnnotationClass(CanBeAutoLoaded::class));
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testClassExistsFallbackNotUsedWhenRegisterFileUsed() : void
+    {
+        AnnotationRegistry::reset();
+        AnnotationRegistry::registerFile(__DIR__ . '/Fixtures/Annotation/LoadedUsingRegisterFile.php');
+
+        self::assertTrue(AnnotationRegistry::loadAnnotationClass(LoadedUsingRegisterFile::class));
+        self::assertFalse(AnnotationRegistry::loadAnnotationClass(ShouldNeverBeLoaded::class));
     }
 }

--- a/tests/Doctrine/Tests/Common/Annotations/Fixtures/Annotation/CanBeAutoLoaded.php
+++ b/tests/Doctrine/Tests/Common/Annotations/Fixtures/Annotation/CanBeAutoLoaded.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Doctrine\Tests\Common\Annotations\Fixtures\Annotation;
+
+/** @Annotation */
+class CanBeAutoLoaded
+{
+}

--- a/tests/Doctrine/Tests/Common/Annotations/Fixtures/Annotation/LoadedUsingRegisterFile.php
+++ b/tests/Doctrine/Tests/Common/Annotations/Fixtures/Annotation/LoadedUsingRegisterFile.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Doctrine\Tests\Common\Annotations\Fixtures\Annotation;
+
+/** @Annotation */
+class LoadedUsingRegisterFile
+{
+}

--- a/tests/Doctrine/Tests/Common/Annotations/Fixtures/Annotation/ShouldNeverBeLoaded.php
+++ b/tests/Doctrine/Tests/Common/Annotations/Fixtures/Annotation/ShouldNeverBeLoaded.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Doctrine\Tests\Common\Annotations\Fixtures\Annotation;
+
+/** @Annotation */
+class ShouldNeverBeLoaded
+{
+}


### PR DESCRIPTION
As v2 isn't here yet, and looking at #232 it is unclear if it will be coming anytime soon, and as we have to put up with annoying deprecated functions, here I propose to fall back to the standard autoloader if nothing else worked, and if there's no custom loader defined.

Fixes #270

I intentionally did not add any tests as this is a PoC. Please tell me if this makes any sence, and then I'll make a try with tests.