### PR TITLE
Fix access array offset on value of type null

### DIFF
--- a/lib/Doctrine/Annotations/DocParser.php
+++ b/lib/Doctrine/Annotations/DocParser.php
@@ -980,7 +980,8 @@ final class DocParser
 
         $className = $this->lexer->token['value'];
 
-        while ($this->lexer->lookahead['position'] === ($this->lexer->token['position'] + strlen($this->lexer->token['value']))
+        while (null !== $this->lexer->lookahead
+                && $this->lexer->lookahead['position'] === ($this->lexer->token['position'] + strlen($this->lexer->token['value']))
                 && $this->lexer->isNextToken(DocLexer::T_NAMESPACE_SEPARATOR)) {
 
             $this->match(DocLexer::T_NAMESPACE_SEPARATOR);


### PR DESCRIPTION
Fix https://github.com/doctrine/annotations/issues/273.

---

I am using Symfony 4.3 with PHP 7.4.0-dev(nightly snapshot). When I do `bin/console cache:clear -vvv`, there is a warning which will be fixed by this PR.

There is another suspicious one as below.
https://github.com/doctrine/annotations/blob/793b91ac63464dff1fa1e949f20214b7eecf6472/lib/Doctrine/Annotations/DocParser.php#L1030
But it seems not causing a problem in my case. Not sure how it will be generally.