### PR TITLE
Fix lookahead on PHP 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ script:
 
 jobs:
   allow_failures:
-    - php: 7.4snapshot
     - php: nightly
 
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ php:
   - 7.1
   - 7.2
   - 7.3
-  - 7.4snapshot
   - nightly
 
 cache:
@@ -27,6 +26,10 @@ jobs:
     - php: nightly
 
   include:
+    - stage: Test
+      php: 7.4snapshot
+      install: travis_retry composer require --dev phpunit/phpunit:^7.5@dev
+
     - stage: Lint
       before_script:
         - travis_retry composer require --dev --prefer-dist --prefer-stable phpstan/phpstan:^0.7

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "require-dev": {
         "doctrine/cache": "1.*",
-        "phpunit/phpunit": "^7.0"
+        "phpunit/phpunit": "^7.5@dev"
     },
     "config": {
         "sort-packages": true

--- a/lib/Doctrine/Common/Annotations/DocParser.php
+++ b/lib/Doctrine/Common/Annotations/DocParser.php
@@ -997,9 +997,11 @@ final class DocParser
 
         $className = $this->lexer->token['value'];
 
-        while ($this->lexer->lookahead['position'] === ($this->lexer->token['position'] + strlen($this->lexer->token['value']))
-                && $this->lexer->isNextToken(DocLexer::T_NAMESPACE_SEPARATOR)) {
-
+        while (
+            null !== $this->lexer->lookahead &&
+            $this->lexer->lookahead['position'] === ($this->lexer->token['position'] + strlen($this->lexer->token['value'])) &&
+            $this->lexer->isNextToken(DocLexer::T_NAMESPACE_SEPARATOR)
+        ) {
             $this->match(DocLexer::T_NAMESPACE_SEPARATOR);
             $this->matchAny(self::$classIdentifiers);
 


### PR DESCRIPTION
Fixes #273, resurrects #274. This PR contains a workaround for an issue in PHPUnit 7.5 that causes a test to fail because of a deprecation. Once the next minor release for PHPUnit 7.5 is released, the last commit can be dropped again.