### PR TITLE
Backporting ignoring phpcsSuppress annotation to 1.8.

### DIFF
--- a/lib/Doctrine/Common/Annotations/AnnotationReader.php
+++ b/lib/Doctrine/Common/Annotations/AnnotationReader.php
@@ -101,7 +101,9 @@ class AnnotationReader implements Reader
         // PlantUML
         'startuml' => true, 'enduml' => true,
         // Symfony 3.3 Cache Adapter
-        'experimental' => true
+        'experimental' => true,
+        // Slevomat Coding Standard
+        'phpcsSuppress' => true,
     ];
 
     /**

--- a/tests/Doctrine/Tests/Common/Annotations/AnnotationReaderTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/AnnotationReaderTest.php
@@ -7,6 +7,7 @@ use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Annotations\DocParser;
 use Doctrine\Tests\Common\Annotations\Fixtures\Annotation\SingleUseAnnotation;
 use Doctrine\Tests\Common\Annotations\Fixtures\ClassWithFullPathUseStatement;
+use Doctrine\Tests\Common\Annotations\Fixtures\ClassWithPhpCsSuppressAnnotation;
 use Doctrine\Tests\Common\Annotations\Fixtures\IgnoredNamespaces\AnnotatedAtClassLevel;
 use Doctrine\Tests\Common\Annotations\Fixtures\IgnoredNamespaces\AnnotatedAtMethodLevel;
 use Doctrine\Tests\Common\Annotations\Fixtures\IgnoredNamespaces\AnnotatedAtPropertyLevel;
@@ -128,5 +129,13 @@ class AnnotationReaderTest extends AbstractReaderTest
         $annotations = $reader->getClassAnnotations($ref);
 
         self::assertInstanceOf(SingleUseAnnotation::class,$annotations[0]);
+    }
+
+    public function testPhpCsSuppressAnnotationIsIgnored()
+    {
+        $reader = $this->getReader();
+        $ref = new \ReflectionClass(ClassWithPhpCsSuppressAnnotation::class);
+
+        self::assertEmpty($reader->getMethodAnnotations($ref->getMethod('foo')));
     }
 }

--- a/tests/Doctrine/Tests/Common/Annotations/Fixtures/ClassWithPhpCsSuppressAnnotation.php
+++ b/tests/Doctrine/Tests/Common/Annotations/Fixtures/ClassWithPhpCsSuppressAnnotation.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Doctrine\Tests\Common\Annotations\Fixtures;
+
+class ClassWithPhpCsSuppressAnnotation
+{
+    /**
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint
+     */
+    public function foo($parameterWithoutTypehint) {
+    }
+}


### PR DESCRIPTION
As promised in https://github.com/doctrine/annotations/issues/277, i'm backporting ignoring `@phpcsSuppress` to `1.8`.

Just to be 100% sure, I've added test-case for this. Not sure if similar test-case exists in `master`. I'll double-check and - if not - will issue PR with test-case for `master` tomorrow, unless it's not needed.