### PR TITLE
Backporting ignoring PHP CodeSniffer annotations to 1.8.

### DIFF
--- a/lib/Doctrine/Common/Annotations/AnnotationReader.php
+++ b/lib/Doctrine/Common/Annotations/AnnotationReader.php
@@ -104,6 +104,9 @@ class AnnotationReader implements Reader
         'experimental' => true,
         // Slevomat Coding Standard
         'phpcsSuppress' => true,
+        // PHP CodeSniffer
+        'codingStandardsIgnoreStart' => true,
+        'codingStandardsIgnoreEnd' => true,
     ];
 
     /**

--- a/tests/Doctrine/Tests/Common/Annotations/AnnotationReaderTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/AnnotationReaderTest.php
@@ -7,6 +7,7 @@ use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Annotations\DocParser;
 use Doctrine\Tests\Common\Annotations\Fixtures\Annotation\SingleUseAnnotation;
 use Doctrine\Tests\Common\Annotations\Fixtures\ClassWithFullPathUseStatement;
+use Doctrine\Tests\Common\Annotations\Fixtures\ClassWithPHPCodeSnifferAnnotation;
 use Doctrine\Tests\Common\Annotations\Fixtures\ClassWithPhpCsSuppressAnnotation;
 use Doctrine\Tests\Common\Annotations\Fixtures\IgnoredNamespaces\AnnotatedAtClassLevel;
 use Doctrine\Tests\Common\Annotations\Fixtures\IgnoredNamespaces\AnnotatedAtMethodLevel;
@@ -155,5 +156,13 @@ class AnnotationReaderTest extends AbstractReaderTest
         } finally {
             spl_autoload_unregister($testLoader);
         }
+    }
+
+    public function testPHPCodeSnifferAnnotationsAreIgnored()
+    {
+        $reader = $this->getReader();
+        $ref = new \ReflectionClass(ClassWithPHPCodeSnifferAnnotation::class);
+
+        self::assertEmpty($reader->getClassAnnotations($ref));
     }
 }

--- a/tests/Doctrine/Tests/Common/Annotations/Fixtures/ClassWithPHPCodeSnifferAnnotation.php
+++ b/tests/Doctrine/Tests/Common/Annotations/Fixtures/ClassWithPHPCodeSnifferAnnotation.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Doctrine\Tests\Common\Annotations\Fixtures;
+
+/**
+ * @codingStandardsIgnoreStart
+ * @codingStandardsIgnoreEnd
+ */
+class ClassWithPHPCodeSnifferAnnotation
+{
+}


### PR DESCRIPTION
Backporting changes made in https://github.com/doctrine/annotations/pull/230 to `1.8` as promised in https://github.com/doctrine/annotations/issues/277. 