### PR TITLE
Backporting adding global ignored annotations to DocParser.

### DIFF
--- a/lib/Doctrine/Common/Annotations/AnnotationReader.php
+++ b/lib/Doctrine/Common/Annotations/AnnotationReader.php
@@ -197,6 +197,7 @@ class AnnotationReader implements Reader
 
         $this->preParser->setImports(self::$globalImports);
         $this->preParser->setIgnoreNotImportedAnnotations(true);
+        $this->preParser->setIgnoredAnnotationNames(self::$globalIgnoredNames);
 
         $this->phpParser = new PhpParser;
     }

--- a/tests/Doctrine/Tests/Common/Annotations/AnnotationReaderTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/AnnotationReaderTest.php
@@ -138,4 +138,22 @@ class AnnotationReaderTest extends AbstractReaderTest
 
         self::assertEmpty($reader->getMethodAnnotations($ref->getMethod('foo')));
     }
+
+    public function testGloballyIgnoredAnnotationNotIgnored() : void
+    {
+        $reader = $this->getReader();
+        $class  = new \ReflectionClass(Fixtures\ClassDDC1660::class);
+        $testLoader = static function (string $className) : bool {
+            if ($className === 'since') {
+                throw new \InvalidArgumentException('Globally ignored annotation names should never be passed to an autoloader.');
+            }
+            return false;
+        };
+        spl_autoload_register($testLoader, true, true);
+        try {
+            self::assertEmpty($reader->getClassAnnotations($class));
+        } finally {
+            spl_autoload_unregister($testLoader);
+        }
+    }
 }


### PR DESCRIPTION
Backporting changes made in https://github.com/doctrine/annotations/pull/235 to `1.8` as promised in https://github.com/doctrine/annotations/issues/277.

Not sure if this is needed since tests are passing even without this change.