### PR TITLE
Fixed DocParser lookahead to work in PHP 7.4

### DIFF
--- a/lib/Doctrine/Annotations/DocParser.php
+++ b/lib/Doctrine/Annotations/DocParser.php
@@ -980,8 +980,11 @@ final class DocParser
 
         $className = $this->lexer->token['value'];
 
-        while ($this->lexer->lookahead['position'] === ($this->lexer->token['position'] + strlen($this->lexer->token['value']))
-                && $this->lexer->isNextToken(DocLexer::T_NAMESPACE_SEPARATOR)) {
+        while (
+            null !== $this->lexer->lookahead &&
+            $this->lexer->lookahead['position'] === ($this->lexer->token['position'] + strlen($this->lexer->token['value'])) &&
+            $this->lexer->isNextToken(DocLexer::T_NAMESPACE_SEPARATOR)
+        ) {
 
             $this->match(DocLexer::T_NAMESPACE_SEPARATOR);
             $this->matchAny(self::$classIdentifiers);

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -30,7 +30,3 @@ parameters:
         -
             message: '#^Array has 2 duplicate keys with value .ClassWithConstants\.SOME_KEY. \(\\Doctrine\\Tests\\Annotations\\Fixtures\\ClassWithConstants::SOME_KEY, \\Doctrine\\Tests\\Annotations\\Fixtures\\ClassWithConstants::SOME_KEY\)\.$#'
             path: '%currentWorkingDirectory%/tests\Doctrine\Tests\Annotations\DocParserTest.php'
-        # bug in doctrine/lexer
-        -
-            message: '#^Call to static method PHPUnit\\Framework\\Assert::assertNull\(\) with array will always evaluate to false\.$#'
-            path: '%currentWorkingDirectory%/tests\Doctrine\Tests\Annotations\DocLexerTest.php'

--- a/tests/Doctrine/Tests/Annotations/AbstractReaderTest.php
+++ b/tests/Doctrine/Tests/Annotations/AbstractReaderTest.php
@@ -478,12 +478,10 @@ abstract class AbstractReaderTest extends TestCase
         $reader = $this->getReader();
         $class  = new \ReflectionClass(Fixtures\ClassDDC1660::class);
 
-        $testLoader = static function (string $className) : bool {
+        $testLoader = static function (string $className) : void {
             if ($className === 'since') {
                 throw new \InvalidArgumentException('Globally ignored annotation names should never be passed to an autoloader.');
             }
-
-            return false;
         };
 
         spl_autoload_register($testLoader, true, true);


### PR DESCRIPTION
Fixes #283 by explicitly checking if the lookahead position is null before using it (started becoming a problem in PHP 7.4).  Also fixed spl autoload function to have a void return type rather than bool.  Removed an error message from the PHPStan config because it is no longer thrown by the fixed DocParser