### PR TITLE
No longer require dev versions of PHPUnit on PHP 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
+  - 7.4snapshot
   - nightly
 
 cache:
@@ -26,10 +27,6 @@ jobs:
     - php: nightly
 
   include:
-    - stage: Test
-      php: 7.4snapshot
-      install: travis_retry composer require --dev phpunit/phpunit:^7.5@dev
-
     - stage: Lint
       before_script:
         - travis_retry composer require --dev --prefer-dist --prefer-stable phpstan/phpstan:^0.7


### PR DESCRIPTION
With a PHP-7.4 compatible release of PHPUnit 7.5 available, we no longer need to rely on installing dev versions of PHPUnit.