### PR TITLE
Improve travis settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,9 @@ cache:
 before_install:
   - mv ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini{,.disabled} || echo "xdebug not available"
 
-install: travis_retry composer update --prefer-dist
+install:
+  - if [[ $TRAVIS_PHP_VERSION = nightly ]]; then export COMPOSER_FLAGS="--ignore-platform-reqs"; fi
+  - travis_retry composer update --prefer-dist $COMPOSER_FLAGS
 
 script:
   - ./vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ cache:
 
 before_install:
   - mv ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini{,.disabled} || echo "xdebug not available"
-  - composer self-update
 
 install: travis_retry composer update --prefer-dist
 


### PR DESCRIPTION
- `sudo:false` is deprecated and doens't do antying anymore
- `compsoer self-update` is already ran by travis anyways.
- dependencies (and this package) don't declare to be compatible with php 8.0. And most probably wont do so for a while, so this allows to still run tests against that version, instead of producing an error when trying to install the dependencies