### PR TITLE
Add support for loading annotations from functions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
             "Doctrine\\Tests\\Common\\Annotations\\": "tests/Doctrine/Tests/Common/Annotations"
         },
         "files": [
+            "tests/Doctrine/Tests/Common/Annotations/Fixtures/functions.php",
             "tests/Doctrine/Tests/Common/Annotations/Fixtures/SingleClassLOC1000.php"
         ]
     },

--- a/docs/en/custom.rst
+++ b/docs/en/custom.rst
@@ -108,7 +108,8 @@ type is applicable. Then you could define one or more targets:
 -  ``CLASS`` Allowed in class docblocks
 -  ``PROPERTY`` Allowed in property docblocks
 -  ``METHOD`` Allowed in the method docblocks
--  ``ALL`` Allowed in class, property and method docblocks
+-  ``FUNCTION`` Allowed in function dockblocks
+-  ``ALL`` Allowed in class, property, method and function docblocks
 -  ``ANNOTATION`` Allowed inside other annotations
 
 If the annotations is not allowed in the current context, an
@@ -397,3 +398,17 @@ Access one annotation of a property
 .. code-block:: php
 
     public function getPropertyAnnotation(\ReflectionProperty $property, $annotationName);
+
+Access all annotations of a function
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: php
+
+    public function getFunctionAnnotations(\ReflectionFunction $property);
+
+Access one annotation of a function
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: php
+
+    public function getFunctionAnnotation(\ReflectionFunction $property, $annotationName);

--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -2,7 +2,7 @@ Introduction
 ============
 
 Doctrine Annotations allows to implement custom annotation
-functionality for PHP classes.
+functionality for PHP classes and functions.
 
 .. code-block:: php
 
@@ -55,7 +55,7 @@ The annotation class is declared as an annotation by ``@Annotation``.
 Reading annotations
 ===================
 
-The access to the annotations happens by reflection of the class
+The access to the annotations happens by reflection of the class or function
 containing them. There are multiple reader-classes implementing the
 ``Doctrine\Common\Annotations\Reader`` interface, that can access the
 annotations of a class. A common one is
@@ -84,7 +84,8 @@ Note that ``AnnotationRegistry::registerLoader('class_exists')`` only works
 if you already have an autoloader configured (i.e. composer autoloader).
 Otherwise, :ref:`please take a look to the other annotation autoload mechanisms <annotations>`.
 
-A reader has multiple methods to access the annotations of a class.
+A reader has multiple methods to access the annotations of a class or
+function.
 
 :ref:`Read more about handling annotations. <annotations>`
 

--- a/lib/Doctrine/Common/Annotations/Annotation/Target.php
+++ b/lib/Doctrine/Common/Annotations/Annotation/Target.php
@@ -25,7 +25,8 @@ final class Target
     public const TARGET_METHOD     = 2;
     public const TARGET_PROPERTY   = 4;
     public const TARGET_ANNOTATION = 8;
-    public const TARGET_ALL        = 15;
+    public const TARGET_FUNCTION   = 16;
+    public const TARGET_ALL        = 31;
 
     /** @var array<string, int> */
     private static $map = [
@@ -33,6 +34,7 @@ final class Target
         'CLASS'      => self::TARGET_CLASS,
         'METHOD'     => self::TARGET_METHOD,
         'PROPERTY'   => self::TARGET_PROPERTY,
+        'FUNCTION'   => self::TARGET_FUNCTION,
         'ANNOTATION' => self::TARGET_ANNOTATION,
     ];
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -151,4 +151,8 @@
         <!-- Usage of mixed case constants seems pretty deliberate here -->
         <exclude-pattern>*/lib/Doctrine/Common/Annotations/ImplicitlyIgnoredAnnotationNames.php</exclude-pattern>
     </rule>
+
+    <rule ref="Squiz.Functions.GlobalFunction.Found">
+        <exclude-pattern>*/tests/Doctrine/Tests/Common/Annotations/Fixtures/functions.php</exclude-pattern>
+    </rule>
 </ruleset>

--- a/tests/Doctrine/Tests/Common/Annotations/AnnotationReaderTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/AnnotationReaderTest.php
@@ -18,6 +18,7 @@ use Doctrine\Tests\Common\Annotations\Fixtures\IgnoredNamespaces\AnnotatedWithAl
 use InvalidArgumentException;
 use LogicException;
 use ReflectionClass;
+use ReflectionFunction;
 
 use function class_exists;
 use function spl_autoload_register;
@@ -274,5 +275,24 @@ class AnnotationReaderTest extends AbstractReaderTest
         $ref    = new ReflectionClass(ClassWithImportedIgnoredAnnotation::class);
 
         self::assertEmpty($reader->getMethodAnnotations($ref->getMethod('something')));
+    }
+
+    public function testFunctionsAnnotation(): void
+    {
+        $reader = $this->getReader();
+        $ref    = new ReflectionFunction('Doctrine\Tests\Common\Annotations\Fixtures\foo');
+
+        $annotations = $reader->getFunctionAnnotations($ref);
+        self::assertCount(1, $annotations);
+        self::assertInstanceOf(Fixtures\Annotation\Autoload::class, $annotations[0]);
+    }
+
+    public function testFunctionAnnotation(): void
+    {
+        $reader = $this->getReader();
+        $ref    = new ReflectionFunction('Doctrine\Tests\Common\Annotations\Fixtures\foo');
+
+        $annotation = $reader->getFunctionAnnotation($ref, Fixtures\Annotation\Autoload::class);
+        self::assertInstanceOf(Fixtures\Annotation\Autoload::class, $annotation);
     }
 }

--- a/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
@@ -1074,7 +1074,7 @@ DOCBLOCK;
         $parser->setTarget(Target::TARGET_CLASS);
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
-            'Invalid Target "Foo". Available targets: [ALL, CLASS, METHOD, PROPERTY, ANNOTATION]'
+            'Invalid Target "Foo". Available targets: [ALL, CLASS, METHOD, PROPERTY, FUNCTION, ANNOTATION]'
         );
         $parser->parse($docblock, $context);
     }

--- a/tests/Doctrine/Tests/Common/Annotations/Fixtures/functions.php
+++ b/tests/Doctrine/Tests/Common/Annotations/Fixtures/functions.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Doctrine\Tests\Common\Annotations\Fixtures;
+
+use Doctrine\Tests\Common\Annotations\Fixtures\Annotation\Autoload;
+
+/**
+ * @Autoload()
+ */
+function foo()
+{
+}


### PR DESCRIPTION
I didn't update the `Reader` interface since it would be a BC break to do so.