### PR TITLE
fix parse annotation locale tr_TR

### DIFF
--- a/lib/Doctrine/Common/Annotations/DocLexer.php
+++ b/lib/Doctrine/Common/Annotations/DocLexer.php
@@ -112,6 +112,14 @@ final class DocLexer extends AbstractLexer
     /**
      * {@inheritdoc}
      */
+    protected function getModifiers()
+    {
+        return parent::getModifiers() . 'u';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function getType(&$value)
     {
         $type = self::T_NONE;

--- a/lib/Doctrine/Common/Annotations/DocLexer.php
+++ b/lib/Doctrine/Common/Annotations/DocLexer.php
@@ -112,14 +112,6 @@ final class DocLexer extends AbstractLexer
     /**
      * {@inheritdoc}
      */
-    protected function getModifiers()
-    {
-        return parent::getModifiers() . 'u';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     protected function getType(&$value)
     {
         $type = self::T_NONE;

--- a/tests/Doctrine/Tests/Common/Annotations/DocLexerTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/DocLexerTest.php
@@ -328,6 +328,8 @@ class DocLexerTest extends TestCase
         self::assertEquals('ODM\Id', $lexer->lookahead['value']);
 
         self::assertFalse($lexer->moveNext());
+
+        setlocale(LC_ALL, null);
     }
 
 }

--- a/tests/Doctrine/Tests/Common/Annotations/DocLexerTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/DocLexerTest.php
@@ -7,6 +7,13 @@ use PHPUnit\Framework\TestCase;
 
 class DocLexerTest extends TestCase
 {
+    /**
+     * {@inheritdoc}
+     */
+    protected function tearDown() {
+        setlocale(LC_ALL, null);
+    }
+
     public function testMarkerAnnotation() : void
     {
         $lexer = new DocLexer;
@@ -328,8 +335,6 @@ class DocLexerTest extends TestCase
         self::assertEquals('ODM\Id', $lexer->lookahead['value']);
 
         self::assertFalse($lexer->moveNext());
-
-        setlocale(LC_ALL, null);
     }
 
 }

--- a/tests/Doctrine/Tests/Common/Annotations/DocLexerTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/DocLexerTest.php
@@ -308,4 +308,26 @@ class DocLexerTest extends TestCase
         self::assertFalse($lexer->nextTokenIsAdjacent());
         self::assertFalse($lexer->moveNext());
     }
+
+    public function testMarkerAnnotationLocaleTr() : void
+    {
+        setlocale(LC_ALL, 'tr_TR.utf8', 'tr_TR');
+
+        $lexer = new DocLexer;
+
+        $lexer->setInput('@ODM\Id');
+        self::assertNull($lexer->token);
+        self::assertNull($lexer->lookahead);
+
+        self::assertTrue($lexer->moveNext());
+        self::assertNull($lexer->token);
+        self::assertEquals('@', $lexer->lookahead['value']);
+
+        self::assertTrue($lexer->moveNext());
+        self::assertEquals('@', $lexer->token['value']);
+        self::assertEquals('ODM\Id', $lexer->lookahead['value']);
+
+        self::assertFalse($lexer->moveNext());
+    }
+
 }

--- a/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
@@ -1398,6 +1398,14 @@ DOCBLOCK;
         self::assertCount(1, $result);
         self::assertInstanceOf(SomeAnnotationClassNameWithoutConstructorAndProperties::class, $result[0]);
     }
+
+    public function testMultiByteAnnotationLocaleTR()
+    {
+        setlocale(LC_ALL, 'tr_TR.utf8', 'tr_TR');
+
+        self::assertCount(1, $this->createTestParser()->parse('@Doctrine\Tests\Common\Annotations\Id'));
+    }
+
 }
 
 /** @Annotation */
@@ -1451,6 +1459,11 @@ class AnnotationExtendsAnnotationTargetAll extends AnnotationTargetAll
 
 /** @Annotation */
 class Name extends Annotation {
+    public $foo;
+}
+
+/** @Annotation */
+class Id extends Annotation {
     public $foo;
 }
 

--- a/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
@@ -1404,6 +1404,8 @@ DOCBLOCK;
         setlocale(LC_ALL, 'tr_TR.utf8', 'tr_TR');
 
         self::assertCount(1, $this->createTestParser()->parse('@Doctrine\Tests\Common\Annotations\Id'));
+
+        setlocale(LC_ALL, null);
     }
 
 }

--- a/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
@@ -15,6 +15,13 @@ use PHPUnit\Framework\TestCase;
 
 class DocParserTest extends TestCase
 {
+    /**
+     * {@inheritdoc}
+     */
+    protected function tearDown() {
+        setlocale(LC_ALL, null);
+    }
+
     public function testNestedArraysWithNestedAnnotation()
     {
         $parser = $this->createTestParser();
@@ -1404,8 +1411,6 @@ DOCBLOCK;
         setlocale(LC_ALL, 'tr_TR.utf8', 'tr_TR');
 
         self::assertCount(1, $this->createTestParser()->parse('@Doctrine\Tests\Common\Annotations\Id'));
-
-        setlocale(LC_ALL, null);
     }
 
 }


### PR DESCRIPTION
Issue https://github.com/doctrine/annotations/issues/265
Class DocLexer not correct parsing multi byte string