### PR TITLE
Ditch doctrine/cache dependency in favor of PSR-16

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,12 @@
     ],
     "require": {
         "php": "^7.1",
-        "doctrine/lexer": "1.*"
+        "doctrine/lexer": "1.*",
+        "psr/simple-cache": "^1.0",
+        "roave/doctrine-simplecache": "^2.3"
     },
     "require-dev": {
+        "cache/array-adapter": "^1.0",
         "doctrine/cache": "1.*",
         "phpunit/phpunit": "^7.5"
     },

--- a/docs/en/annotations.rst
+++ b/docs/en/annotations.rst
@@ -107,7 +107,22 @@ is very important during development. If you don't set it to true you have to de
 This gives faster performance, however should only be used in production, because of its inconvenience
 during development.
 
-You can also use one of the ``Doctrine\Common\Cache\Cache`` cache implementations to cache the annotations:
+You can use a PSR-16 cache implementation to cache the annotations:
+
+.. code-block:: php
+
+    use Doctrine\Common\Annotations\AnnotationReader;
+    use Doctrine\Common\Annotations\CachedReader;
+
+    $reader = CachedReader::fromPsr16Cache(
+        new AnnotationReader(),
+        new Psr16CacheImplementation(),
+        $debug = true
+    );
+
+You can also use one of the ``Doctrine\Common\Cache\Cache`` cache
+implementations to cache the annotations, but please note that doing so
+is deprecated:
 
 .. code-block:: php
 

--- a/tests/Doctrine/Tests/Common/Annotations/AbstractReaderTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/AbstractReaderTest.php
@@ -4,6 +4,7 @@ namespace Doctrine\Tests\Common\Annotations;
 
 use Doctrine\Common\Annotations\Annotation;
 use Doctrine\Common\Annotations\AnnotationException;
+use Doctrine\Common\Annotations\Reader;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass, Doctrine\Common\Annotations\AnnotationReader;
 
@@ -470,7 +471,7 @@ abstract class AbstractReaderTest extends TestCase
     }
 
     /**
-     * @return AnnotationReader
+     * @return Reader
      */
     abstract protected function getReader();
 }


### PR DESCRIPTION
This shows how we could proceed to get rid of `doctrine/cache` entirely