### PR TITLE
Ignore PHPStan generics annotations

### DIFF
--- a/lib/Doctrine/Common/Annotations/AnnotationReader.php
+++ b/lib/Doctrine/Common/Annotations/AnnotationReader.php
@@ -107,6 +107,8 @@ class AnnotationReader implements Reader
         // PHP CodeSniffer
         'codingStandardsIgnoreStart' => true,
         'codingStandardsIgnoreEnd' => true,
+        // PHPStan
+        'template' => true, 'implements' => true, 'extends' => true,
     ];
 
     /**

--- a/lib/Doctrine/Common/Annotations/AnnotationReader.php
+++ b/lib/Doctrine/Common/Annotations/AnnotationReader.php
@@ -108,7 +108,7 @@ class AnnotationReader implements Reader
         'codingStandardsIgnoreStart' => true,
         'codingStandardsIgnoreEnd' => true,
         // PHPStan
-        'template' => true, 'implements' => true, 'extends' => true,
+        'template' => true, 'implements' => true, 'extends' => true, 'use' => true,
     ];
 
     /**

--- a/tests/Doctrine/Tests/Common/Annotations/AnnotationReaderTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/AnnotationReaderTest.php
@@ -175,5 +175,9 @@ class AnnotationReaderTest extends AbstractReaderTest
         self::assertEmpty($reader->getClassAnnotations($ref));
         self::assertEmpty($reader->getPropertyAnnotations($ref->getProperty('bar')));
         self::assertEmpty($reader->getMethodAnnotations($ref->getMethod('foo')));
+
+        $this->expectException('\Doctrine\Common\Annotations\AnnotationException');
+        $this->expectExceptionMessage('[Semantical Error] The annotation "@Template" in method Doctrine\Tests\Common\Annotations\Fixtures\ClassWithPHPStanGenericsAnnotations::twigTemplateFunctionName() was never imported.');
+        self::assertEmpty($reader->getMethodAnnotations($ref->getMethod('twigTemplateFunctionName')));
     }
 }

--- a/tests/Doctrine/Tests/Common/Annotations/AnnotationReaderTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/AnnotationReaderTest.php
@@ -12,6 +12,7 @@ use Doctrine\Tests\Common\Annotations\Fixtures\ClassWithPhpCsSuppressAnnotation;
 use Doctrine\Tests\Common\Annotations\Fixtures\IgnoredNamespaces\AnnotatedAtClassLevel;
 use Doctrine\Tests\Common\Annotations\Fixtures\IgnoredNamespaces\AnnotatedAtMethodLevel;
 use Doctrine\Tests\Common\Annotations\Fixtures\IgnoredNamespaces\AnnotatedAtPropertyLevel;
+use Doctrine\Tests\Common\Annotations\Fixtures\ClassWithPHPStanGenericsAnnotations;
 
 class AnnotationReaderTest extends AbstractReaderTest
 {
@@ -164,5 +165,15 @@ class AnnotationReaderTest extends AbstractReaderTest
         $ref = new \ReflectionClass(ClassWithPHPCodeSnifferAnnotation::class);
 
         self::assertEmpty($reader->getClassAnnotations($ref));
+    }
+
+    public function testPHPStanGenericsAnnotationsAreIgnored()
+    {
+        $reader = $this->getReader();
+        $ref = new \ReflectionClass(ClassWithPHPStanGenericsAnnotations::class);
+
+        self::assertEmpty($reader->getClassAnnotations($ref));
+        self::assertEmpty($reader->getPropertyAnnotations($ref->getProperty('bar')));
+        self::assertEmpty($reader->getMethodAnnotations($ref->getMethod('foo')));
     }
 }

--- a/tests/Doctrine/Tests/Common/Annotations/Fixtures/ClassWithPHPStanGenericsAnnotations.php
+++ b/tests/Doctrine/Tests/Common/Annotations/Fixtures/ClassWithPHPStanGenericsAnnotations.php
@@ -20,11 +20,24 @@ class ClassWithPHPStanExtendsAnnotationsGeneric
 
 /**
  * @template T
+ */
+trait GenericPHPStanTrait
+{
+
+}
+
+/**
+ * @template T
  * @implements WithPHPStanExtendsAnnotationsInterface<int>
  * @extends ClassWithPHPStanExtendsAnnotationsGeneric<int>
  */
 class ClassWithPHPStanGenericsAnnotations extends ClassWithPHPStanExtendsAnnotationsGeneric implements WithPHPStanExtendsAnnotationsInterface
 {
+    /**
+     * @use GenericPHPStanTrait<T>
+     */
+    use GenericPHPStanTrait;
+
     /**
      * @var array<T>
      */

--- a/tests/Doctrine/Tests/Common/Annotations/Fixtures/ClassWithPHPStanGenericsAnnotations.php
+++ b/tests/Doctrine/Tests/Common/Annotations/Fixtures/ClassWithPHPStanGenericsAnnotations.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Doctrine\Tests\Common\Annotations\Fixtures;
+
+/**
+ * @template T
+ */
+interface WithPHPStanExtendsAnnotationsInterface
+{
+
+}
+
+/**
+ * @template T
+ */
+class ClassWithPHPStanExtendsAnnotationsGeneric
+{
+
+}
+
+/**
+ * @template T
+ * @implements WithPHPStanExtendsAnnotationsInterface<int>
+ * @extends ClassWithPHPStanExtendsAnnotationsGeneric<int>
+ */
+class ClassWithPHPStanGenericsAnnotations extends ClassWithPHPStanExtendsAnnotationsGeneric implements WithPHPStanExtendsAnnotationsInterface
+{
+    /**
+     * @var array<T>
+     */
+    private $bar;
+
+    /**
+     * @param array<T> $array
+     *
+     * @return array<T>
+     */
+    public function foo($array)
+    {
+        return $this->bar;
+    }
+}

--- a/tests/Doctrine/Tests/Common/Annotations/Fixtures/ClassWithPHPStanGenericsAnnotations.php
+++ b/tests/Doctrine/Tests/Common/Annotations/Fixtures/ClassWithPHPStanGenericsAnnotations.php
@@ -52,4 +52,12 @@ class ClassWithPHPStanGenericsAnnotations extends ClassWithPHPStanExtendsAnnotat
     {
         return $this->bar;
     }
+
+    /**
+     * @Template("@foo.html.twig")
+     */
+    public function twigTemplateFunctionName()
+    {
+
+    }
 }


### PR DESCRIPTION
Added @template, @extends and @implements from PHPStan to globally ignored annotations list.

- https://medium.com/@ondrejmirtes/generics-in-php-using-phpdocs-14e7301953
- https://github.com/phpstan/phpstan/issues/2450