### PR TITLE
Respect ignored namespaces when imported in use statement

### DIFF
--- a/lib/Doctrine/Common/Annotations/DocParser.php
+++ b/lib/Doctrine/Common/Annotations/DocParser.php
@@ -736,6 +736,10 @@ final class DocParser
         $name = ltrim($name,'\\');
 
         if ( ! $this->classExists($name)) {
+            if ($this->isIgnoredAnnotation($name)) {
+                return false;
+            }
+
             throw AnnotationException::semanticalError(sprintf('The annotation "@%s" in %s does not exist, or could not be auto-loaded.', $name, $this->context));
         }
 

--- a/tests/Doctrine/Tests/Common/Annotations/AnnotationReaderTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/AnnotationReaderTest.php
@@ -12,6 +12,7 @@ use Doctrine\Tests\Common\Annotations\Fixtures\ClassWithPhpCsSuppressAnnotation;
 use Doctrine\Tests\Common\Annotations\Fixtures\IgnoredNamespaces\AnnotatedAtClassLevel;
 use Doctrine\Tests\Common\Annotations\Fixtures\IgnoredNamespaces\AnnotatedAtMethodLevel;
 use Doctrine\Tests\Common\Annotations\Fixtures\IgnoredNamespaces\AnnotatedAtPropertyLevel;
+use Doctrine\Tests\Common\Annotations\Fixtures\IgnoredNamespaces\AnnotatedAtPropertyLevelWithUseStatement;
 
 class AnnotationReaderTest extends AbstractReaderTest
 {
@@ -108,6 +109,21 @@ class AnnotationReaderTest extends AbstractReaderTest
     {
         $reader = $this->getReader();
         $ref = new \ReflectionClass(AnnotatedAtPropertyLevel::class);
+
+        $reader::addGlobalIgnoredNamespace('SomePropertyAnnotationNamespace');
+
+        self::assertEmpty($reader->getPropertyAnnotations($ref->getProperty('property')));
+    }
+
+    /**
+     * @group 45
+     *
+     * @runInSeparateProcess
+     */
+    public function testPropertyAnnotationWithUseStatementIsIgnored() : void
+    {
+        $reader = $this->getReader();
+        $ref = new \ReflectionClass(AnnotatedAtPropertyLevelWithUseStatement::class);
 
         $reader::addGlobalIgnoredNamespace('SomePropertyAnnotationNamespace');
 

--- a/tests/Doctrine/Tests/Common/Annotations/Fixtures/IgnoredNamespaces/AnnotatedAtPropertyLevelWithUseStatement.php
+++ b/tests/Doctrine/Tests/Common/Annotations/Fixtures/IgnoredNamespaces/AnnotatedAtPropertyLevelWithUseStatement.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Doctrine\Tests\Common\Annotations\Fixtures\IgnoredNamespaces;
+
+use SomePropertyAnnotationNamespace\Subnamespace;
+
+class AnnotatedAtPropertyLevelWithUseStatement
+{
+    /**
+     * @Subnamespace\Name
+     */
+    private $property;
+}


### PR DESCRIPTION
Fixes #302, ping @re2bit.

When a use statement is found for a relative annotation class, it is always marked as found, which bypasses the ignored namespace check. However, if the class itself does not exist, an exception is thrown even though the namespace is ignored. This PR fixes that issue.