### PR TITLE
Fix broken autoloading due to Reader calling registerFile

### DIFF
--- a/lib/Doctrine/Common/Annotations/AnnotationReader.php
+++ b/lib/Doctrine/Common/Annotations/AnnotationReader.php
@@ -194,7 +194,8 @@ class AnnotationReader implements Reader
             throw AnnotationException::optimizerPlusSaveComments();
         }
 
-        AnnotationRegistry::registerFile(__DIR__ . '/Annotation/IgnoreAnnotation.php');
+        // Make sure that the IgnoreAnnotation annotation is loaded
+        class_exists(IgnoreAnnotation::class);
 
         $this->parser = $parser ?: new DocParser();
 

--- a/lib/Doctrine/Common/Annotations/DocParser.php
+++ b/lib/Doctrine/Common/Annotations/DocParser.php
@@ -490,10 +490,11 @@ final class DocParser
                 'attributes'    => 'Doctrine\Common\Annotations\Annotation\Attributes'
             ]);
 
-            AnnotationRegistry::registerFile(__DIR__ . '/Annotation/Enum.php');
-            AnnotationRegistry::registerFile(__DIR__ . '/Annotation/Target.php');
-            AnnotationRegistry::registerFile(__DIR__ . '/Annotation/Attribute.php');
-            AnnotationRegistry::registerFile(__DIR__ . '/Annotation/Attributes.php');
+            // Make sure that annotations from metadata are loaded
+            class_exists(Enum::class);
+            class_exists(Target::class);
+            class_exists(Attribute::class);
+            class_exists(Attributes::class);
         }
 
         $class      = new \ReflectionClass($name);


### PR DESCRIPTION
As pointed out by @lcobucci, since the annotation reader invokes `AnnotationRegistry::registerFile`, we automatically disable the autoload mechanism. This PR fixes this behaviour by exchanging calls to `registerFile` by `class_exists`, invoking the standard autoloader we always assume to be present.