### PR TITLE
Update DocParser.php

### DIFF
--- a/lib/Doctrine/Common/Annotations/DocParser.php
+++ b/lib/Doctrine/Common/Annotations/DocParser.php
@@ -937,7 +937,7 @@ final class DocParser
             switch (true) {
                 case !empty ($this->namespaces):
                     foreach ($this->namespaces as $ns) {
-                        if (class_exists($ns.'\\'.$className) || interface_exists($ns.'\\'.$className)) {
+                        if ($this->classExists($ns.'\\'.$className) || interface_exists($ns.'\\'.$className)) {
                              $className = $ns.'\\'.$className;
                              $found = true;
                              break;
@@ -956,7 +956,7 @@ final class DocParser
                     if(isset($this->imports['__NAMESPACE__'])) {
                         $ns = $this->imports['__NAMESPACE__'];
 
-                        if (class_exists($ns.'\\'.$className) || interface_exists($ns.'\\'.$className)) {
+                        if ($this->classExists($ns.'\\'.$className) || interface_exists($ns.'\\'.$className)) {
                             $className = $ns.'\\'.$className;
                             $found = true;
                         }


### PR DESCRIPTION
When we use the class name of the relative path, it will automatically require the php file. 
examples:
namespace App;
@Inject(Demo::class)

class_exists(Demo::class, false) will return true.

When we use the full path class name, it will not.
examples:
namespace App;
@Inject("App\Demo")

class_exists(Demo::class, false) will return false.

I think it's up to the user to decide whether the file is loaded or not.