### PR TITLE
Allow php 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ php:
   - 7.2
   - 7.3
   - 7.4
-  - nightly
 
 cache:
   directories:
@@ -26,6 +25,11 @@ jobs:
     - php: nightly
 
   include:
+    - stage: Test
+      php: nightly
+      before_install:
+        - composer config platform.php 7.4.99
+
     - stage: Lint
       before_script:
         - travis_retry composer require --dev --prefer-dist --prefer-stable phpstan/phpstan:^0.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,7 @@ cache:
 before_install:
   - mv ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini{,.disabled} || echo "xdebug not available"
 
-install:
-  - if [[ $TRAVIS_PHP_VERSION = nightly ]]; then export COMPOSER_FLAGS="--ignore-platform-reqs"; fi
-  - travis_retry composer update --prefer-dist $COMPOSER_FLAGS
+install: travis_retry composer update --prefer-dist
 
 script:
   - ./vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         {"name": "Johannes Schmitt", "email": "schmittjoh@gmail.com"}
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.1 || ^8.0",
         "ext-tokenizer": "*",
         "doctrine/lexer": "1.*"
     },


### PR DESCRIPTION
The CI passes, the next logical step would be to get reports from
downstream users. This allows to remove the ignore-platform-reqs flag
when installing dependencies in the CI.
The nightly job is kept in "allow_failures", since we should not create
a sense of urgency about this.

I'm targeting 1.10.x so that this restriction can be lifted ASAP