### PR TITLE
Allow using PHPUnit 9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ jobs:
       php: nightly
       before_install:
         - composer config platform.php 7.4.99
+        - composer config minimum-stability dev
 
     - stage: Lint
       before_script:


### PR DESCRIPTION
That is the only version that is compatible with PHP 8.
Lowering the minimum-stability on the nightly build is necessary until
9.3.0 is published.