### PR TITLE
Add support for the new PHP 8 tokens for use statements

### DIFF
--- a/lib/Doctrine/Common/Annotations/TokenParser.php
+++ b/lib/Doctrine/Common/Annotations/TokenParser.php
@@ -106,12 +106,14 @@ class TokenParser
         $statements = [];
         $explicitAlias = false;
         while (($token = $this->next())) {
-            $isNameToken = $token[0] === T_STRING || $token[0] === T_NS_SEPARATOR;
-            if (!$explicitAlias && $isNameToken) {
+            if (!$explicitAlias && $token[0] === T_STRING) {
                 $class .= $token[1];
                 $alias = $token[1];
-            } else if ($explicitAlias && $isNameToken) {
-                $alias .= $token[1];
+            } else if ($explicitAlias && $token[0] === T_STRING) {
+                $alias = $token[1];
+            } else if ($token[0] === T_NS_SEPARATOR) {
+                $class .= '\\';
+                $alias = '';
             } else if ($token[0] === T_AS) {
                 $explicitAlias = true;
                 $alias = '';

--- a/lib/Doctrine/Common/Annotations/TokenParser.php
+++ b/lib/Doctrine/Common/Annotations/TokenParser.php
@@ -111,6 +111,11 @@ class TokenParser
                 $alias = $token[1];
             } else if ($explicitAlias && $token[0] === T_STRING) {
                 $alias = $token[1];
+            } else if (\PHP_VERSION_ID >= 80000 && ($token[0] === T_NAME_QUALIFIED || $token[0] === T_NAME_FULLY_QUALIFIED)) {
+                $class .= $token[1];
+
+                $classSplit = explode('\\', $token[1]);
+                $alias = $classSplit[count($classSplit) - 1];
             } else if ($token[0] === T_NS_SEPARATOR) {
                 $class .= '\\';
                 $alias = '';
@@ -174,7 +179,7 @@ class TokenParser
     public function parseNamespace()
     {
         $name = '';
-        while (($token = $this->next()) && ($token[0] === T_STRING || $token[0] === T_NS_SEPARATOR)) {
+        while (($token = $this->next()) && ($token[0] === T_STRING || $token[0] === T_NS_SEPARATOR || (\PHP_VERSION_ID >= 80000 && ($token[0] === T_NAME_QUALIFIED || $token[0] === T_NAME_FULLY_QUALIFIED)))) {
             $name .= $token[1];
         }
 

--- a/lib/Doctrine/Common/Annotations/TokenParser.php
+++ b/lib/Doctrine/Common/Annotations/TokenParser.php
@@ -179,7 +179,10 @@ class TokenParser
     public function parseNamespace()
     {
         $name = '';
-        while (($token = $this->next()) && ($token[0] === T_STRING || $token[0] === T_NS_SEPARATOR || (\PHP_VERSION_ID >= 80000 && ($token[0] === T_NAME_QUALIFIED || $token[0] === T_NAME_FULLY_QUALIFIED)))) {
+        while (($token = $this->next()) && ($token[0] === T_STRING || $token[0] === T_NS_SEPARATOR || (
+            \PHP_VERSION_ID >= 80000 &&
+            ($token[0] === T_NAME_QUALIFIED || $token[0] === T_NAME_FULLY_QUALIFIED)
+        ))) {
             $name .= $token[1];
         }
 


### PR DESCRIPTION
Fixes #339
Replaces #344

This PR achieves the same goal than #344 but without forking the whole method. This is done by first refactoring the existing code to differentiate between `T_STRING` and `T_NS_SEPARATOR` as they actually have different needs (`T_NS_SEPARATOR` won't appear in a explicit alias for instance) and then adding the support for the new PHP 8 tokens in this cleaned code.
For the second commit, I marked @shyim as a co-author to credit them for the good work done in #344 to make the feature work.