### PR TITLE
Remove unneeded rule exclusion

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -79,9 +79,4 @@
     <rule ref="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFullyQualifiedName">
         <exclude-pattern>*/tests/Doctrine/Tests/Common/Annotations/PhpParserTest.php</exclude-pattern>
     </rule>
-
-    <!-- https://github.com/slevomat/coding-standard/issues/1067 -->
-    <rule ref="SlevomatCodingStandard.ControlStructures.EarlyExit.UselessElse">
-        <exclude-pattern>*/lib/Doctrine/Common/Annotations/TokenParser.php</exclude-pattern>
-    </rule>
 </ruleset>


### PR DESCRIPTION
It was added before fixing another cs issue (usage of else if) that is
not supported by phpcs and causes an unwanted code change.

See https://github.com/slevomat/coding-standard/issues/1067