### PR TITLE
Revert to stable minimum stability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ jobs:
       php: nightly
       before_install:
         - composer config platform.php 7.4.99
-        - composer config minimum-stability dev
 
     - stage: Lint
       before_script:


### PR DESCRIPTION
PHPUnit 9.3 has been released.
This reverts commit ffb19cfca102c8e7347e69863b272dca30beddc2.