### PR TITLE
Allow usage of self:: accessor for constants

### DIFF
--- a/lib/Doctrine/Common/Annotations/AnnotationReader.php
+++ b/lib/Doctrine/Common/Annotations/AnnotationReader.php
@@ -331,7 +331,10 @@ class AnnotationReader implements Reader
         $this->imports[$name] = array_merge(
             self::$globalImports,
             $this->phpParser->parseClass($class),
-            ['__NAMESPACE__' => $class->getNamespaceName()]
+            [
+                '__NAMESPACE__' => $class->getNamespaceName(),
+                'self' => $name,
+            ]
         );
 
         $this->ignoredAnnotationNames[$name] = $ignoredAnnotationNames;

--- a/tests/Doctrine/Tests/Common/Annotations/AnnotationReaderTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/AnnotationReaderTest.php
@@ -78,6 +78,67 @@ class AnnotationReaderTest extends AbstractReaderTest
         self::assertEquals([], $annotations);
     }
 
+    public function testClassAnnotationSupportsSelfAccessorForConstants(): void
+    {
+        $reader = $this->getReader();
+        $ref    = new ReflectionClass(Fixtures\ClassWithAnnotationWithSelfConstantReference::class);
+
+        $annotations = $reader->getClassAnnotations($ref);
+
+        self::assertCount(1, $annotations);
+
+        $annotation = $annotations[0];
+        self::assertInstanceOf(Fixtures\AnnotationWithConstants::class, $annotation);
+        self::assertEquals(
+            $annotation->value,
+            Fixtures\ClassWithAnnotationWithSelfConstantReference::VALUE_FOR_CLASS
+        );
+    }
+
+    public function testPropertyAnnotationSupportsSelfAccessorForConstants(): void
+    {
+        $reader = $this->getReader();
+        $ref    = new ReflectionClass(Fixtures\ClassWithAnnotationWithSelfConstantReference::class);
+
+        $classProperty   = $ref->getProperty('classProperty');
+        $classAnnotation = $reader->getPropertyAnnotation($classProperty, Fixtures\AnnotationWithConstants::class);
+        self::assertNotNull($classAnnotation);
+        self::assertEquals(
+            $classAnnotation->value,
+            Fixtures\ClassWithAnnotationWithSelfConstantReference::VALUE_FOR_CLASS
+        );
+
+        $traitProperty   = $ref->getProperty('traitProperty');
+        $traitAnnotation = $reader->getPropertyAnnotation($traitProperty, Fixtures\AnnotationWithConstants::class);
+        self::assertNotNull($traitAnnotation);
+        self::assertEquals(
+            $traitAnnotation->value,
+            Fixtures\ClassWithAnnotationWithSelfConstantReference::VALUE_FOR_TRAIT
+        );
+    }
+
+    public function testMethodAnnotationSupportsSelfAccessorForConstants(): void
+    {
+        $reader = $this->getReader();
+        $ref    = new ReflectionClass(Fixtures\ClassWithAnnotationWithSelfConstantReference::class);
+
+        $classMethod     = $ref->getMethod('classMethod');
+        $classAnnotation = $reader->getMethodAnnotation($classMethod, Fixtures\AnnotationWithConstants::class);
+        self::assertNotNull($classAnnotation);
+        self::assertEquals(
+            $classAnnotation->value,
+            Fixtures\ClassWithAnnotationWithSelfConstantReference::VALUE_FOR_CLASS
+        );
+
+        $traitMethod     = $ref->getMethod('traitMethod');
+        $traitAnnotation = $reader->getMethodAnnotation($traitMethod, Fixtures\AnnotationWithConstants::class);
+        self::assertNotNull($traitAnnotation);
+        self::assertEquals(
+            $traitAnnotation->value,
+            Fixtures\ClassWithAnnotationWithSelfConstantReference::VALUE_FOR_TRAIT
+        );
+    }
+
     /**
      * @group 45
      * @runInSeparateProcess

--- a/tests/Doctrine/Tests/Common/Annotations/Fixtures/ClassWithAnnotationWithSelfConstantReference.php
+++ b/tests/Doctrine/Tests/Common/Annotations/Fixtures/ClassWithAnnotationWithSelfConstantReference.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Doctrine\Tests\Common\Annotations\Fixtures;
+
+use Doctrine\Tests\Common\Annotations\Fixtures\Traits\TraitWithSelfConstantReferenceTrait;
+
+/** @AnnotationWithConstants(self::VALUE_FOR_CLASS) */
+class ClassWithAnnotationWithSelfConstantReference
+{
+    use TraitWithSelfConstantReferenceTrait;
+
+    public const VALUE_FOR_CLASS = 'ClassWithAnnotationWithSelfConstantReference.VALUE_FROM_CLASS';
+    public const VALUE_FOR_TRAIT = 'ClassWithAnnotationWithSelfConstantReference.VALUE_FOR_TRAIT';
+
+    /**
+     * @var mixed
+     * @AnnotationWithConstants(self::VALUE_FOR_CLASS)
+     */
+    private $classProperty;
+
+    /**
+     * @return mixed
+     *
+     * @AnnotationWithConstants(self::VALUE_FOR_CLASS)
+     */
+    public function classMethod()
+    {
+        return $this->classProperty;
+    }
+}

--- a/tests/Doctrine/Tests/Common/Annotations/Fixtures/Traits/TraitWithSelfConstantReferenceTrait.php
+++ b/tests/Doctrine/Tests/Common/Annotations/Fixtures/Traits/TraitWithSelfConstantReferenceTrait.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Doctrine\Tests\Common\Annotations\Fixtures\Traits;
+
+use Doctrine\Tests\Common\Annotations\Fixtures\AnnotationWithConstants;
+
+trait TraitWithSelfConstantReferenceTrait
+{
+    /**
+     * @var mixed
+     * @AnnotationWithConstants(self::VALUE_FOR_TRAIT)
+     */
+    private $traitProperty;
+
+    /** @AnnotationWithConstants(self::VALUE_FOR_TRAIT) */
+    public function traitMethod(): void
+    {
+    }
+}


### PR DESCRIPTION
ex: `@Annotation(self::VALUE)`
Fixes #269