### PR TITLE
Add compatibility with named parameters and constructor property promotion

### DIFF
--- a/docs/en/custom.rst
+++ b/docs/en/custom.rst
@@ -53,6 +53,52 @@ values into public properties directly:
         public $bar;
     }
 
+Optional: Constructors with Named Parameters
+--------------------------------------------
+
+Starting with Annotations v1.11 a new annotation instantiation strategy
+is available that aims at compatibility of Annotation classes with the PHP 8
+attribute feature.
+
+You can implement the
+``Doctrine\Common\Annotations\NamedArgumentConstructorAnnotation`` interface
+and then declare a constructor with regular parameter names that are matched
+from the named arguments in the annotation syntax.
+
+.. code-block:: php
+
+    namespace MyCompany\Annotations;
+
+    use Doctrine\Common\Annotations\NamedArgumentConstructorAnnotation;
+
+    /** @Annotation */
+    class Bar implements NamedArgumentConstructorAnnotation
+    {
+        private $foo;
+
+        public function __construct(string $foo)
+        {
+            $this->foo = $foo;
+        }
+    }
+
+    /** Useable with @Bar(foo="baz") */
+
+In combination with PHP 8s constructor property promotion feature
+you can simplify this to:
+
+.. code-block:: php
+
+    namespace MyCompany\Annotations;
+
+    use Doctrine\Common\Annotations\NamedArgumentConstructorAnnotation;
+
+    /** @Annotation */
+    class Bar implements NamedArgumentConstructorAnnotation
+    {
+        public function __construct(private string $foo) {}
+    }
+
 Annotation Target
 -----------------
 

--- a/docs/en/custom.rst
+++ b/docs/en/custom.rst
@@ -84,7 +84,7 @@ from the named arguments in the annotation syntax.
 
     /** Useable with @Bar(foo="baz") */
 
-In combination with PHP 8s constructor property promotion feature
+In combination with PHP 8's constructor property promotion feature
 you can simplify this to:
 
 .. code-block:: php

--- a/lib/Doctrine/Common/Annotations/DocParser.php
+++ b/lib/Doctrine/Common/Annotations/DocParser.php
@@ -24,6 +24,7 @@ use function in_array;
 use function interface_exists;
 use function is_array;
 use function is_object;
+use function is_subclass_of;
 use function json_encode;
 use function ltrim;
 use function preg_match;
@@ -37,6 +38,8 @@ use function strrpos;
 use function strtolower;
 use function substr;
 use function trim;
+
+use const PHP_VERSION_ID;
 
 /**
  * A parser for docblock annotations.

--- a/lib/Doctrine/Common/Annotations/NamedArgumentConstructorAnnotation.php
+++ b/lib/Doctrine/Common/Annotations/NamedArgumentConstructorAnnotation.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Doctrine\Common\Annotations;
+
+/**
+ * Marker interface for PHP7/PHP8 compatible support
+ * for named arguments (and constructor property promotion).
+ */
+interface NamedArgumentConstructorAnnotation
+{
+}

--- a/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
@@ -7,6 +7,7 @@ use Doctrine\Common\Annotations\Annotation\Target;
 use Doctrine\Common\Annotations\AnnotationException;
 use Doctrine\Common\Annotations\AnnotationRegistry;
 use Doctrine\Common\Annotations\DocParser;
+use Doctrine\Common\Annotations\NamedArgumentConstructorAnnotation;
 use Doctrine\Tests\Common\Annotations\Fixtures\AnnotationTargetAll;
 use Doctrine\Tests\Common\Annotations\Fixtures\AnnotationWithConstants;
 use Doctrine\Tests\Common\Annotations\Fixtures\ClassWithConstants;
@@ -1536,6 +1537,53 @@ DOCBLOCK;
 
         self::assertCount(1, $result);
         self::assertInstanceOf(SomeAnnotationClassNameWithoutConstructorAndProperties::class, $result[0]);
+    }
+
+    public function testNamedArgumentsConstructorAnnotation(): void
+    {
+        $result = $this
+            ->createTestParser()
+            ->parse('/** @NamedAnnotation(bar=2222, foo="baz") */');
+
+        self::assertCount(1, $result);
+        self::assertInstanceOf(NamedAnnotation::class, $result[0]);
+        self::assertSame("baz", $result[0]->getFoo());
+        self::assertSame(2222, $result[0]->getBar());
+    }
+
+    public function testNamedArgumentsConstructorAnnotationWithDefaultValue(): void
+    {
+        $result = $this
+            ->createTestParser()
+            ->parse('/** @NamedAnnotation(foo="baz") */');
+
+        self::assertCount(1, $result);
+        self::assertInstanceOf(NamedAnnotation::class, $result[0]);
+        self::assertSame("baz", $result[0]->getFoo());
+        self::assertSame(1234, $result[0]->getBar());
+    }
+}
+
+/** @Annotation */
+class NamedAnnotation implements NamedArgumentConstructorAnnotation
+{
+    private $foo;
+    private $bar;
+
+    public function __construct(string $foo, int $bar = 1234)
+    {
+        $this->foo = $foo;
+        $this->bar = $bar;
+    }
+
+    public function getFoo() : string
+    {
+        return $this->foo;
+    }
+
+    public function getBar() : int
+    {
+        return $this->bar;
     }
 }
 

--- a/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
@@ -1547,7 +1547,7 @@ DOCBLOCK;
 
         self::assertCount(1, $result);
         self::assertInstanceOf(NamedAnnotation::class, $result[0]);
-        self::assertSame("baz", $result[0]->getFoo());
+        self::assertSame('baz', $result[0]->getFoo());
         self::assertSame(2222, $result[0]->getBar());
     }
 
@@ -1559,7 +1559,7 @@ DOCBLOCK;
 
         self::assertCount(1, $result);
         self::assertInstanceOf(NamedAnnotation::class, $result[0]);
-        self::assertSame("baz", $result[0]->getFoo());
+        self::assertSame('baz', $result[0]->getFoo());
         self::assertSame(1234, $result[0]->getBar());
     }
 }
@@ -1567,7 +1567,9 @@ DOCBLOCK;
 /** @Annotation */
 class NamedAnnotation implements NamedArgumentConstructorAnnotation
 {
+    /** @var string */
     private $foo;
+    /** @var int */
     private $bar;
 
     public function __construct(string $foo, int $bar = 1234)
@@ -1576,12 +1578,12 @@ class NamedAnnotation implements NamedArgumentConstructorAnnotation
         $this->bar = $bar;
     }
 
-    public function getFoo() : string
+    public function getFoo(): string
     {
         return $this->foo;
     }
 
-    public function getBar() : int
+    public function getBar(): int
     {
         return $this->bar;
     }

--- a/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
@@ -1543,6 +1543,18 @@ DOCBLOCK;
     {
         $result = $this
             ->createTestParser()
+            ->parse('/** @NamedAnnotation(foo="baz", bar=2222) */');
+
+        self::assertCount(1, $result);
+        self::assertInstanceOf(NamedAnnotation::class, $result[0]);
+        self::assertSame('baz', $result[0]->getFoo());
+        self::assertSame(2222, $result[0]->getBar());
+    }
+
+    public function testNamedReorderedArgumentsConstructorAnnotation(): void
+    {
+        $result = $this
+            ->createTestParser()
             ->parse('/** @NamedAnnotation(bar=2222, foo="baz") */');
 
         self::assertCount(1, $result);


### PR DESCRIPTION
With PHP 8 the combination of named parameters and constructor property
promotion will be very cool for the new Attributes feature, but also for
Doctrine's Annotation feature. Especially if classes are to be used
for both Attributes and Annotations, then the DocParser needs
a compatible support for named parameters in annotation class constructors.

For backwards compatibility this is done with a marker interface that
uses a different instantiation logic than the current one. Currently
all annotations properties are passed as a single array argument
$values.

This patch uses reflection to match annotation values to class
constructor parameters. For PHP 8 the integration of named arguments
with spread operator is used.

A PHP 8 class that could be read using Doctrine Annotations would
become:

```
/** @Annotation */
class Table implements NamedArgumentConstructorAnnotation
{
    public function __construct(
        public string $name,
        public array $indexes = []
    ) {}
}
/** @Table(name="users") */
/** @Table(name="users", indexes={"foo"}) */
```