### PR TITLE
Relax phpdoc typing

### DIFF
--- a/lib/Doctrine/Common/Annotations/AnnotationException.php
+++ b/lib/Doctrine/Common/Annotations/AnnotationException.php
@@ -128,10 +128,10 @@ class AnnotationException extends Exception
     /**
      * Creates a new AnnotationException describing a invalid enummerator.
      *
-     * @param string              $attributeName
-     * @param string              $annotationName
-     * @param string              $context
-     * @param object|class-string $given
+     * @param string $attributeName
+     * @param string $annotationName
+     * @param string $context
+     * @param mixed  $given
      *
      * @return AnnotationException
      *


### PR DESCRIPTION
That method can be called with more than just class-string, see for
instance this test:
https://github.com/doctrine/annotations/blob/1.11.x/tests/Doctrine/Tests/Common/Annotations/Fixtures/ClassWithAnnotationEnum.php#L24