### PR TITLE
Remove "--no-suggest" option from Composer commands

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -32,7 +32,7 @@ jobs:
           restore-keys: "php-${{ matrix.php-version }}-composer-locked-"
 
       - name: "Install dependencies with Composer"
-        run: "composer install --no-interaction --no-progress --no-suggest"
+        run: "composer install --no-interaction --no-progress"
 
       # https://github.com/doctrine/.github/issues/3
       - name: "Run PHP_CodeSniffer"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -50,11 +50,11 @@ jobs:
           restore-keys: "php-${{ matrix.php-version }}-composer-locked-"
 
       - name: "Update dependencies with composer"
-        run: "composer update --no-interaction --no-progress --no-suggest"
+        run: "composer update --no-interaction --no-progress"
         if: "${{ matrix.deps == 'normal' }}"
 
       - name: "Install lowest possible dependencies with composer"
-        run: "composer update --no-interaction --no-progress --no-suggest --prefer-dist --prefer-lowest"
+        run: "composer update --no-interaction --no-progress --prefer-dist --prefer-lowest"
         if: "${{ matrix.deps == 'low' }}"
 
       - name: "Run PHPUnit"

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -39,7 +39,7 @@ jobs:
           restore-keys: "php-${{ matrix.php-version }}-composer-locked-"
 
       - name: "Install dependencies with composer"
-        run: "composer install --no-interaction --no-progress --no-suggest"
+        run: "composer install --no-interaction --no-progress"
 
       - name: "Run a static analysis with phpstan/phpstan"
         run: "vendor/bin/phpstan analyse -l 3 -c phpstan.neon --error-format=checkstyle lib/ tests/ | cs2pr"


### PR DESCRIPTION
As it is deprecated in Composer 2:

> ```You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.```