### PR TITLE
Fix badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # Doctrine Annotations
 
-[![Build Status](https://travis-ci.org/doctrine/annotations.svg?branch=master)](https://travis-ci.org/doctrine/annotations)
-[![Dependency Status](https://www.versioneye.com/package/php--doctrine--annotations/badge.png)](https://www.versioneye.com/package/php--doctrine--annotations)
-[![Reference Status](https://www.versioneye.com/php/doctrine:annotations/reference_badge.svg)](https://www.versioneye.com/php/doctrine:annotations/references)
+[![Build Status](https://github.com/doctrine/annotations/workflows/Continuous%20Integration/badge.svg?label=build)](https://github.com/doctrine/persistence/actions)
 [![Total Downloads](https://poser.pugx.org/doctrine/annotations/downloads.png)](https://packagist.org/packages/doctrine/annotations)
-[![Latest Stable Version](https://poser.pugx.org/doctrine/annotations/v/stable.png)](https://packagist.org/packages/doctrine/annotations)
+[![Latest Stable Version](https://img.shields.io/packagist/v/doctrine/annotations.svg?label=stable)](https://packagist.org/packages/doctrine/annotations)
 
 Docblock Annotations Parser library (extracted from [Doctrine Common](https://github.com/doctrine/common)).
 


### PR DESCRIPTION
Fixes:
 - replaced build badge for Travis with CI one for Github Actions
 - removed both versioneye badges as they are not working anymore
 - replaced badge for the stable to use shields.io one as it shows full tag name (including `v`)