### PR TITLE
Fix link to Coding Standard Guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ See the [doctrine-project website](https://www.doctrine-project.org/projects/doc
 ## Contributing
 
 When making a pull request, make sure your changes follow the
-[Coding Standard Guidelines](https://www.doctrine-project.org/projects/doctrine-coding-standard/en/latest/reference/index.html#introduction).
+[Coding Standard Guidelines](https://www.doctrine-project.org/projects/doctrine-coding-standard/en/current/reference/index.html#introduction).
 
 ## Changelog
 


### PR DESCRIPTION
As the old one was not working.