### PR TITLE
Introduced annotation NamedArgumentConstructor

### DIFF
--- a/docs/en/custom.rst
+++ b/docs/en/custom.rst
@@ -99,6 +99,22 @@ you can simplify this to:
         public function __construct(private string $foo) {}
     }
 
+Alternatively, you can annotate your annotation class with
+``@NamedArgumentConstructor`` in case you cannot use the marker interface.
+
+.. code-block:: php
+
+    namespace MyCompany\Annotations;
+
+    /**
+     * @Annotation
+     * @NamedArgumentConstructor
+     */
+    class Bar
+    {
+        public function __construct(private string $foo) {}
+    }
+
 Annotation Target
 -----------------
 

--- a/lib/Doctrine/Common/Annotations/Annotation/NamedArgumentConstructor.php
+++ b/lib/Doctrine/Common/Annotations/Annotation/NamedArgumentConstructor.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Doctrine\Common\Annotations\Annotation;
+
+/**
+ * Annotation that indicates that the annotated class should be constructed with a named argument call.
+ *
+ * @Annotation
+ * @Target("CLASS")
+ */
+final class NamedArgumentConstructor
+{
+}

--- a/lib/Doctrine/Common/Annotations/DocParser.php
+++ b/lib/Doctrine/Common/Annotations/DocParser.php
@@ -145,14 +145,14 @@ final class DocParser
      */
     private static $annotationMetadata = [
         Annotation\Target::class => [
-            'is_annotation'         => true,
-            'has_constructor'       => true,
-            'has_named_constructor' => false,
-            'properties'            => [],
-            'targets_literal'       => 'ANNOTATION_CLASS',
-            'targets'               => Target::TARGET_CLASS,
-            'default_property'      => 'value',
-            'attribute_types'       => [
+            'is_annotation'                  => true,
+            'has_constructor'                => true,
+            'has_named_argument_constructor' => false,
+            'properties'                     => [],
+            'targets_literal'                => 'ANNOTATION_CLASS',
+            'targets'                        => Target::TARGET_CLASS,
+            'default_property'               => 'value',
+            'attribute_types'                => [
                 'value'  => [
                     'required'   => false,
                     'type'       => 'array',
@@ -162,18 +162,18 @@ final class DocParser
             ],
         ],
         Annotation\Attribute::class => [
-            'is_annotation'         => true,
-            'has_constructor'       => false,
-            'has_named_constructor' => false,
-            'targets_literal'       => 'ANNOTATION_ANNOTATION',
-            'targets'               => Target::TARGET_ANNOTATION,
-            'default_property'      => 'name',
-            'properties'            => [
+            'is_annotation'                  => true,
+            'has_constructor'                => false,
+            'has_named_argument_constructor' => false,
+            'targets_literal'                => 'ANNOTATION_ANNOTATION',
+            'targets'                        => Target::TARGET_ANNOTATION,
+            'default_property'               => 'name',
+            'properties'                     => [
                 'name'      => 'name',
                 'type'      => 'type',
                 'required'  => 'required',
             ],
-            'attribute_types'       => [
+            'attribute_types'                => [
                 'value'  => [
                     'required'  => true,
                     'type'      => 'string',
@@ -192,14 +192,14 @@ final class DocParser
             ],
         ],
         Annotation\Attributes::class => [
-            'is_annotation'         => true,
-            'has_constructor'       => false,
-            'has_named_constructor' => false,
-            'targets_literal'       => 'ANNOTATION_CLASS',
-            'targets'               => Target::TARGET_CLASS,
-            'default_property'      => 'value',
-            'properties'            => ['value' => 'value'],
-            'attribute_types'       => [
+            'is_annotation'                  => true,
+            'has_constructor'                => false,
+            'has_named_argument_constructor' => false,
+            'targets_literal'                => 'ANNOTATION_CLASS',
+            'targets'                        => Target::TARGET_CLASS,
+            'default_property'               => 'value',
+            'properties'                     => ['value' => 'value'],
+            'attribute_types'                => [
                 'value' => [
                     'type'      => 'array',
                     'required'  => true,
@@ -209,14 +209,14 @@ final class DocParser
             ],
         ],
         Annotation\Enum::class => [
-            'is_annotation'         => true,
-            'has_constructor'       => true,
-            'has_named_constructor' => false,
-            'targets_literal'       => 'ANNOTATION_PROPERTY',
-            'targets'               => Target::TARGET_PROPERTY,
-            'default_property'      => 'value',
-            'properties'            => ['value' => 'value'],
-            'attribute_types'       => [
+            'is_annotation'                  => true,
+            'has_constructor'                => true,
+            'has_named_argument_constructor' => false,
+            'targets_literal'                => 'ANNOTATION_PROPERTY',
+            'targets'                        => Target::TARGET_PROPERTY,
+            'default_property'               => 'value',
+            'properties'                     => ['value' => 'value'],
+            'attribute_types'                => [
                 'value' => [
                     'type'      => 'array',
                     'required'  => true,
@@ -228,14 +228,14 @@ final class DocParser
             ],
         ],
         Annotation\NamedArgumentConstructor::class => [
-            'is_annotation'         => true,
-            'has_constructor'       => false,
-            'has_named_constructor' => false,
-            'targets_literal'       => 'ANNOTATION_CLASS',
-            'targets'               => Target::TARGET_CLASS,
-            'default_property'      => null,
-            'properties'            => [],
-            'attribute_types'       => [],
+            'is_annotation'                  => true,
+            'has_constructor'                => false,
+            'has_named_argument_constructor' => false,
+            'targets_literal'                => 'ANNOTATION_CLASS',
+            'targets'                        => Target::TARGET_CLASS,
+            'default_property'               => null,
+            'properties'                     => [],
+            'attribute_types'                => [],
         ],
     ];
 
@@ -530,7 +530,7 @@ final class DocParser
             'is_annotation'    => strpos($docComment, '@Annotation') !== false,
         ];
 
-        $metadata['has_named_constructor'] = $metadata['has_constructor']
+        $metadata['has_named_argument_constructor'] = $metadata['has_constructor']
             && $class->implementsInterface(NamedArgumentConstructorAnnotation::class);
 
         // verify that the class is really meant to be an annotation
@@ -546,7 +546,7 @@ final class DocParser
                 }
 
                 if ($annotation instanceof NamedArgumentConstructor) {
-                    $metadata['has_named_constructor'] = $metadata['has_constructor'];
+                    $metadata['has_named_argument_constructor'] = $metadata['has_constructor'];
                 }
 
                 if (! ($annotation instanceof Attributes)) {
@@ -603,7 +603,7 @@ final class DocParser
 
                 // choose the first property as default property
                 $metadata['default_property'] = reset($metadata['properties']);
-            } elseif (PHP_VERSION_ID < 80000 && $metadata['has_named_constructor']) {
+            } elseif (PHP_VERSION_ID < 80000 && $metadata['has_named_argument_constructor']) {
                 foreach ($constructor->getParameters() as $parameter) {
                     $metadata['constructor_args'][$parameter->getName()] = [
                         'position' => $parameter->getPosition(),
@@ -931,7 +931,7 @@ EXCEPTION
             }
         }
 
-        if (self::$annotationMetadata[$name]['has_named_constructor']) {
+        if (self::$annotationMetadata[$name]['has_named_argument_constructor']) {
             if (PHP_VERSION_ID >= 80000) {
                 return new $name(...$values);
             }

--- a/lib/Doctrine/Common/Annotations/DocParser.php
+++ b/lib/Doctrine/Common/Annotations/DocParser.php
@@ -5,6 +5,7 @@ namespace Doctrine\Common\Annotations;
 use Doctrine\Common\Annotations\Annotation\Attribute;
 use Doctrine\Common\Annotations\Annotation\Attributes;
 use Doctrine\Common\Annotations\Annotation\Enum;
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 use Doctrine\Common\Annotations\Annotation\Target;
 use ReflectionClass;
 use ReflectionException;
@@ -24,7 +25,6 @@ use function in_array;
 use function interface_exists;
 use function is_array;
 use function is_object;
-use function is_subclass_of;
 use function json_encode;
 use function ltrim;
 use function preg_match;
@@ -145,33 +145,35 @@ final class DocParser
      */
     private static $annotationMetadata = [
         Annotation\Target::class => [
-            'is_annotation'    => true,
-            'has_constructor'  => true,
-            'properties'       => [],
-            'targets_literal'  => 'ANNOTATION_CLASS',
-            'targets'          => Target::TARGET_CLASS,
-            'default_property' => 'value',
-            'attribute_types'  => [
+            'is_annotation'         => true,
+            'has_constructor'       => true,
+            'has_named_constructor' => false,
+            'properties'            => [],
+            'targets_literal'       => 'ANNOTATION_CLASS',
+            'targets'               => Target::TARGET_CLASS,
+            'default_property'      => 'value',
+            'attribute_types'       => [
                 'value'  => [
-                    'required'  => false,
-                    'type'      => 'array',
+                    'required'   => false,
+                    'type'       => 'array',
                     'array_type' => 'string',
-                    'value'     => 'array<string>',
+                    'value'      => 'array<string>',
                 ],
             ],
         ],
         Annotation\Attribute::class => [
-            'is_annotation'    => true,
-            'has_constructor'  => false,
-            'targets_literal'  => 'ANNOTATION_ANNOTATION',
-            'targets'          => Target::TARGET_ANNOTATION,
-            'default_property' => 'name',
-            'properties'       => [
+            'is_annotation'         => true,
+            'has_constructor'       => false,
+            'has_named_constructor' => false,
+            'targets_literal'       => 'ANNOTATION_ANNOTATION',
+            'targets'               => Target::TARGET_ANNOTATION,
+            'default_property'      => 'name',
+            'properties'            => [
                 'name'      => 'name',
                 'type'      => 'type',
                 'required'  => 'required',
             ],
-            'attribute_types'  => [
+            'attribute_types'       => [
                 'value'  => [
                     'required'  => true,
                     'type'      => 'string',
@@ -190,13 +192,14 @@ final class DocParser
             ],
         ],
         Annotation\Attributes::class => [
-            'is_annotation'    => true,
-            'has_constructor'  => false,
-            'targets_literal'  => 'ANNOTATION_CLASS',
-            'targets'          => Target::TARGET_CLASS,
-            'default_property' => 'value',
-            'properties'       => ['value' => 'value'],
-            'attribute_types'  => [
+            'is_annotation'         => true,
+            'has_constructor'       => false,
+            'has_named_constructor' => false,
+            'targets_literal'       => 'ANNOTATION_CLASS',
+            'targets'               => Target::TARGET_CLASS,
+            'default_property'      => 'value',
+            'properties'            => ['value' => 'value'],
+            'attribute_types'       => [
                 'value' => [
                     'type'      => 'array',
                     'required'  => true,
@@ -206,13 +209,14 @@ final class DocParser
             ],
         ],
         Annotation\Enum::class => [
-            'is_annotation'    => true,
-            'has_constructor'  => true,
-            'targets_literal'  => 'ANNOTATION_PROPERTY',
-            'targets'          => Target::TARGET_PROPERTY,
-            'default_property' => 'value',
-            'properties'       => ['value' => 'value'],
-            'attribute_types'  => [
+            'is_annotation'         => true,
+            'has_constructor'       => true,
+            'has_named_constructor' => false,
+            'targets_literal'       => 'ANNOTATION_PROPERTY',
+            'targets'               => Target::TARGET_PROPERTY,
+            'default_property'      => 'value',
+            'properties'            => ['value' => 'value'],
+            'attribute_types'       => [
                 'value' => [
                     'type'      => 'array',
                     'required'  => true,
@@ -222,6 +226,16 @@ final class DocParser
                     'required'  => false,
                 ],
             ],
+        ],
+        Annotation\NamedArgumentConstructor::class => [
+            'is_annotation'         => true,
+            'has_constructor'       => false,
+            'has_named_constructor' => false,
+            'targets_literal'       => 'ANNOTATION_CLASS',
+            'targets'               => Target::TARGET_CLASS,
+            'default_property'      => null,
+            'properties'            => [],
+            'attribute_types'       => [],
         ],
     ];
 
@@ -484,10 +498,11 @@ final class DocParser
             self::$metadataParser->setIgnoreNotImportedAnnotations(true);
             self::$metadataParser->setIgnoredAnnotationNames($this->ignoredAnnotationNames);
             self::$metadataParser->setImports([
-                'enum'          => Annotation\Enum::class,
-                'target'        => Annotation\Target::class,
-                'attribute'     => Annotation\Attribute::class,
-                'attributes'    => Annotation\Attributes::class,
+                'enum'                     => Enum::class,
+                'target'                   => Target::class,
+                'attribute'                => Attribute::class,
+                'attributes'               => Attributes::class,
+                'namedargumentconstructor' => NamedArgumentConstructor::class,
             ]);
 
             // Make sure that annotations from metadata are loaded
@@ -495,6 +510,7 @@ final class DocParser
             class_exists(Target::class);
             class_exists(Attribute::class);
             class_exists(Attributes::class);
+            class_exists(NamedArgumentConstructor::class);
         }
 
         $class      = new ReflectionClass($name);
@@ -514,14 +530,8 @@ final class DocParser
             'is_annotation'    => strpos($docComment, '@Annotation') !== false,
         ];
 
-        if (PHP_VERSION_ID < 80000 && $class->implementsInterface(NamedArgumentConstructorAnnotation::class)) {
-            foreach ($constructor->getParameters() as $parameter) {
-                $metadata['constructor_args'][$parameter->getName()] = [
-                    'position' => $parameter->getPosition(),
-                    'default' => $parameter->isOptional() ? $parameter->getDefaultValue() : null,
-                ];
-            }
-        }
+        $metadata['has_named_constructor'] = $metadata['has_constructor']
+            && $class->implementsInterface(NamedArgumentConstructorAnnotation::class);
 
         // verify that the class is really meant to be an annotation
         if ($metadata['is_annotation']) {
@@ -533,6 +543,10 @@ final class DocParser
                     $metadata['targets_literal'] = $annotation->literal;
 
                     continue;
+                }
+
+                if ($annotation instanceof NamedArgumentConstructor) {
+                    $metadata['has_named_constructor'] = $metadata['has_constructor'];
                 }
 
                 if (! ($annotation instanceof Attributes)) {
@@ -589,6 +603,13 @@ final class DocParser
 
                 // choose the first property as default property
                 $metadata['default_property'] = reset($metadata['properties']);
+            } elseif (PHP_VERSION_ID < 80000 && $metadata['has_named_constructor']) {
+                foreach ($constructor->getParameters() as $parameter) {
+                    $metadata['constructor_args'][$parameter->getName()] = [
+                        'position' => $parameter->getPosition(),
+                        'default' => $parameter->isOptional() ? $parameter->getDefaultValue() : null,
+                    ];
+                }
             }
         }
 
@@ -910,7 +931,7 @@ EXCEPTION
             }
         }
 
-        if (is_subclass_of($name, NamedArgumentConstructorAnnotation::class)) {
+        if (self::$annotationMetadata[$name]['has_named_constructor']) {
             if (PHP_VERSION_ID >= 80000) {
                 return new $name(...$values);
             }

--- a/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Tests\Common\Annotations;
 
 use Doctrine\Common\Annotations\Annotation;
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 use Doctrine\Common\Annotations\Annotation\Target;
 use Doctrine\Common\Annotations\AnnotationException;
 use Doctrine\Common\Annotations\AnnotationRegistry;
@@ -1539,7 +1540,7 @@ DOCBLOCK;
         self::assertInstanceOf(SomeAnnotationClassNameWithoutConstructorAndProperties::class, $result[0]);
     }
 
-    public function testNamedArgumentsConstructorAnnotation(): void
+    public function testNamedArgumentsConstructorInterface(): void
     {
         $result = $this
             ->createTestParser()
@@ -1551,7 +1552,7 @@ DOCBLOCK;
         self::assertSame(2222, $result[0]->getBar());
     }
 
-    public function testNamedReorderedArgumentsConstructorAnnotation(): void
+    public function testNamedReorderedArgumentsConstructorInterface(): void
     {
         $result = $this
             ->createTestParser()
@@ -1563,7 +1564,7 @@ DOCBLOCK;
         self::assertSame(2222, $result[0]->getBar());
     }
 
-    public function testNamedArgumentsConstructorAnnotationWithDefaultValue(): void
+    public function testNamedArgumentsConstructorInterfaceWithDefaultValue(): void
     {
         $result = $this
             ->createTestParser()
@@ -1574,10 +1575,74 @@ DOCBLOCK;
         self::assertSame('baz', $result[0]->getFoo());
         self::assertSame(1234, $result[0]->getBar());
     }
+
+    public function testNamedArgumentsConstructorAnnotation(): void
+    {
+        $result = $this
+            ->createTestParser()
+            ->parse('/** @AnotherNamedAnnotation(foo="baz", bar=2222) */');
+
+        self::assertCount(1, $result);
+        self::assertInstanceOf(AnotherNamedAnnotation::class, $result[0]);
+        self::assertSame('baz', $result[0]->getFoo());
+        self::assertSame(2222, $result[0]->getBar());
+    }
+
+    public function testNamedReorderedArgumentsConstructorAnnotation(): void
+    {
+        $result = $this
+            ->createTestParser()
+            ->parse('/** @AnotherNamedAnnotation(bar=2222, foo="baz") */');
+
+        self::assertCount(1, $result);
+        self::assertInstanceOf(AnotherNamedAnnotation::class, $result[0]);
+        self::assertSame('baz', $result[0]->getFoo());
+        self::assertSame(2222, $result[0]->getBar());
+    }
+
+    public function testNamedArgumentsConstructorAnnotationWithDefaultValue(): void
+    {
+        $result = $this
+            ->createTestParser()
+            ->parse('/** @AnotherNamedAnnotation(foo="baz") */');
+
+        self::assertCount(1, $result);
+        self::assertInstanceOf(AnotherNamedAnnotation::class, $result[0]);
+        self::assertSame('baz', $result[0]->getFoo());
+        self::assertSame(1234, $result[0]->getBar());
+    }
 }
 
 /** @Annotation */
 class NamedAnnotation implements NamedArgumentConstructorAnnotation
+{
+    /** @var string */
+    private $foo;
+    /** @var int */
+    private $bar;
+
+    public function __construct(string $foo, int $bar = 1234)
+    {
+        $this->foo = $foo;
+        $this->bar = $bar;
+    }
+
+    public function getFoo(): string
+    {
+        return $this->foo;
+    }
+
+    public function getBar(): int
+    {
+        return $this->bar;
+    }
+}
+
+/**
+ * @Annotation
+ * @NamedArgumentConstructor
+ */
+class AnotherNamedAnnotation
 {
     /** @var string */
     private $foo;


### PR DESCRIPTION
Fixes #379

This PR enables annotations to provide a constructor to be called with named arguments without requiring to implement a marker interface.