### PR TITLE
Ignore .phpunit.result.cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /phpbench.json
 /phpunit.xml
 /.phpcs-cache
+/.phpunit.result.cache


### PR DESCRIPTION
Running the test suite with PHPUnit 9.5 will create a `.phpunit.result.cache` file. I'd like to propose to ignore it.