### PR TITLE
Add PSR-compatible cached annotations reader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,13 +15,15 @@
     "require": {
         "php": "^7.1 || ^8.0",
         "ext-tokenizer": "*",
-        "doctrine/lexer": "1.*"
+        "doctrine/lexer": "1.*",
+        "psr/cache": "^1 || ^2 || ^3"
     },
     "require-dev": {
         "doctrine/cache": "1.*",
         "doctrine/coding-standard": "^6.0 || ^8.1",
         "phpstan/phpstan": "^0.12.20",
-        "phpunit/phpunit": "^7.5 || ^9.1.5"
+        "phpunit/phpunit": "^7.5 || ^9.1.5",
+        "symfony/cache": "^4.4 || ^5.2"
     },
     "config": {
         "sort-packages": true

--- a/docs/en/annotations.rst
+++ b/docs/en/annotations.rst
@@ -116,39 +116,20 @@ This creates a simple annotation reader with no caching other than in
 memory (in php arrays). Since parsing docblocks can be expensive you
 should cache this process by using a caching reader.
 
-You can use a file caching reader, but please note it is deprecated to
-do so:
-
-.. code-block:: php
-
-    use Doctrine\Common\Annotations\FileCacheReader;
-    use Doctrine\Common\Annotations\AnnotationReader;
-
-    $reader = new FileCacheReader(
-        new AnnotationReader(),
-        "/path/to/cache",
-        $debug = true
-    );
-
-If you set the ``debug`` flag to ``true`` the cache reader will check
-for changes in the original files, which is very important during
-development. If you don't set it to ``true`` you have to delete the
-directory to clear the cache. This gives faster performance, however
-should only be used in production, because of its inconvenience during
-development.
-
-You can also use one of the ``Doctrine\Common\Cache\Cache`` cache
-implementations to cache the annotations:
+To cache annotations, you can create a ``Doctrine\Common\Annotations\PsrCachedReader``.
+This reader decorates the original reader and stores all annotations in a PSR-6
+cache:
 
 .. code-block:: php
 
     use Doctrine\Common\Annotations\AnnotationReader;
-    use Doctrine\Common\Annotations\CachedReader;
-    use Doctrine\Common\Cache\ApcCache;
+    use Doctrine\Common\Annotations\PsrCachedReader;
 
-    $reader = new CachedReader(
+    $cache = ... // instantiate a PSR-6 Cache pool
+
+    $reader = new PsrCachedReader(
         new AnnotationReader(),
-        new ApcCache(),
+        $cache,
         $debug = true
     );
 

--- a/lib/Doctrine/Common/Annotations/FileCacheReader.php
+++ b/lib/Doctrine/Common/Annotations/FileCacheReader.php
@@ -33,7 +33,7 @@ use function var_export;
  *
  * @deprecated the FileCacheReader is deprecated and will be removed
  *             in version 2.0.0 of doctrine/annotations. Please use the
- *             {@see \Doctrine\Common\Annotations\CachedReader} instead.
+ *             {@see \Doctrine\Common\Annotations\PsrCachedReader} instead.
  */
 class FileCacheReader implements Reader
 {

--- a/tests/Doctrine/Tests/Common/Annotations/PsrCachedReaderTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/PsrCachedReaderTest.php
@@ -1,0 +1,292 @@
+<?php
+
+namespace Doctrine\Tests\Common\Annotations;
+
+use Closure;
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\Annotations\PsrCachedReader;
+use Doctrine\Common\Annotations\Reader;
+use Doctrine\Tests\Common\Annotations\Fixtures\Annotation\Route;
+use Doctrine\Tests\Common\Annotations\Fixtures\ClassThatUsesTraitThatUsesAnotherTraitWithMethods;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+use ReflectionClass;
+use ReflectionMethod;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\CacheItem;
+
+use function rawurlencode;
+use function time;
+use function touch;
+
+final class PsrCachedReaderTest extends AbstractReaderTest
+{
+    /** @var CacheItemPoolInterface */
+    private $cache;
+
+    public function testIgnoresStaleCache(): void
+    {
+        $cache = time() - 10;
+        touch(__DIR__ . '/Fixtures/Controller.php', $cache + 10);
+
+        $this->doTestCacheStale(Fixtures\Controller::class, $cache);
+    }
+
+    /**
+     * @group 62
+     */
+    public function testIgnoresStaleCacheWithParentClass(): void
+    {
+        $cache = time() - 10;
+        touch(__DIR__ . '/Fixtures/ControllerWithParentClass.php', $cache - 10);
+        touch(__DIR__ . '/Fixtures/AbstractController.php', $cache + 10);
+
+        $this->doTestCacheStale(Fixtures\ControllerWithParentClass::class, $cache);
+    }
+
+    /**
+     * @group 62
+     */
+    public function testIgnoresStaleCacheWithTraits(): void
+    {
+        $cache = time() - 10;
+        touch(__DIR__ . '/Fixtures/ControllerWithTrait.php', $cache - 10);
+        touch(__DIR__ . '/Fixtures/Traits/SecretRouteTrait.php', $cache + 10);
+
+        $this->doTestCacheStale(Fixtures\ControllerWithTrait::class, $cache);
+    }
+
+    /**
+     * @group 62
+     */
+    public function testIgnoresStaleCacheWithTraitsThatUseOtherTraits(): void
+    {
+        $cache = time() - 10;
+
+        touch(__DIR__ . '/Fixtures/ClassThatUsesTraitThatUsesAnotherTrait.php', $cache - 10);
+        touch(__DIR__ . '/Fixtures/Traits/EmptyTrait.php', $cache + 10);
+
+        $this->doTestCacheStale(
+            Fixtures\ClassThatUsesTraitThatUsesAnotherTrait::class,
+            $cache
+        );
+    }
+
+    /**
+     * @group 62
+     */
+    public function testIgnoresStaleCacheWithInterfacesThatExtendOtherInterfaces(): void
+    {
+        $cache = time() - 10;
+
+        touch(__DIR__ . '/Fixtures/InterfaceThatExtendsAnInterface.php', $cache - 10);
+        touch(__DIR__ . '/Fixtures/EmptyInterface.php', $cache + 10);
+
+        $this->doTestCacheStale(
+            Fixtures\InterfaceThatExtendsAnInterface::class,
+            $cache
+        );
+    }
+
+    /**
+     * @group 62
+     * @group 105
+     */
+    public function testUsesFreshCacheWithTraitsThatUseOtherTraits(): void
+    {
+        $cacheTime = time();
+
+        touch(__DIR__ . '/Fixtures/ClassThatUsesTraitThatUsesAnotherTrait.php', $cacheTime - 10);
+        touch(__DIR__ . '/Fixtures/Traits/EmptyTrait.php', $cacheTime - 10);
+
+        $this->doTestCacheFresh(
+            'Doctrine\Tests\Common\Annotations\Fixtures\ClassThatUsesTraitThatUsesAnotherTrait',
+            $cacheTime
+        );
+    }
+
+    /**
+     * @group 62
+     */
+    public function testPurgeLoadedAnnotations(): void
+    {
+        $cache = time() - 10;
+
+        touch(__DIR__ . '/Fixtures/ClassThatUsesTraitThatUsesAnotherTrait.php', $cache - 10);
+        touch(__DIR__ . '/Fixtures/Traits/EmptyTrait.php', $cache + 10);
+
+        $reader = $this->doTestCacheStale(
+            Fixtures\ClassThatUsesTraitThatUsesAnotherTrait::class,
+            $cache
+        );
+
+        $classReader = new ReflectionClass(PsrCachedReader::class);
+
+        $loadedAnnotationsProperty = $classReader->getProperty('loadedAnnotations');
+        $loadedAnnotationsProperty->setAccessible(true);
+        $this->assertCount(1, $loadedAnnotationsProperty->getValue($reader));
+
+        $loadedFilemtimesProperty = $classReader->getProperty('loadedFilemtimes');
+        $loadedFilemtimesProperty->setAccessible(true);
+        $this->assertCount(3, $loadedFilemtimesProperty->getValue($reader));
+
+        $reader->clearLoadedAnnotations();
+
+        $this->assertCount(0, $loadedAnnotationsProperty->getValue($reader));
+        $this->assertCount(0, $loadedFilemtimesProperty->getValue($reader));
+    }
+
+    /**
+     * As there is a cache on loadedAnnotations, we need to test two different
+     * methods' annotations of the same file
+     *
+     * We test four things
+     * 1. we load the file (and its filemtime) for method1's annotation with fresh cache
+     * 2. we load the file for method2 with stale cache => but still no save, because seen as fresh
+     * 3. we purge loaded annotations and filemtime
+     * 4. same as 2, but this time without filemtime cache, so file seen as stale and new cache is saved
+     *
+     * @group 62
+     * @group 105
+     */
+    public function testAvoidCallingFilemtimeTooMuch(): void
+    {
+        $className = ClassThatUsesTraitThatUsesAnotherTraitWithMethods::class;
+        $cacheTime = time() - 10;
+
+        $cacheKeyMethod1 = rawurlencode($className . '#method1');
+        $cacheKeyMethod2 = rawurlencode($className . '#method2');
+
+        $route1          = new Route();
+        $route1->pattern = '/someprefix';
+        $route2          = new Route();
+        $route2->pattern = '/someotherprefix';
+
+        $cacheItem1     = $this->createCacheItem($cacheKeyMethod1, true, [$route1]);
+        $timeCacheItem1 = $this->createCacheItem('[C]' . $cacheKeyMethod1, true, $cacheTime);
+
+        $cacheItem2     = $this->createCacheItem($cacheKeyMethod2, true, [$route2]);
+        $timeCacheItem2 = $this->createCacheItem('[C]' . $cacheKeyMethod2, true, $cacheTime);
+
+        $cache = $this->createMock(CacheItemPoolInterface::class);
+        $cache
+            ->method('getItem')
+            ->willReturnMap([
+                [$cacheKeyMethod1, $cacheItem1],
+                [$cacheKeyMethod2, $cacheItem2],
+                ['[C]' . $cacheKeyMethod1, $timeCacheItem1],
+                ['[C]' . $cacheKeyMethod2, $timeCacheItem2],
+            ]);
+        $cache
+            ->expects($this->exactly(2))
+            ->method('save')
+            ->withConsecutive(
+                [$timeCacheItem2],
+                [$cacheItem2]
+            );
+
+        $reader = new PsrCachedReader(new AnnotationReader(), $cache, true);
+
+        touch(__DIR__ . '/Fixtures/ClassThatUsesTraitThatUsesAnotherTraitWithMethods.php', $cacheTime - 20);
+        touch(__DIR__ . '/Fixtures/Traits/EmptyTrait.php', $cacheTime - 20);
+        $this->assertEquals([$route1], $reader->getMethodAnnotations(new ReflectionMethod($className, 'method1')));
+
+        // only filemtime changes, but not cleared => no change
+        touch(__DIR__ . '/Fixtures/ClassThatUsesTraitThatUsesAnotherTrait.php', $cacheTime + 5);
+        touch(__DIR__ . '/Fixtures/Traits/EmptyTrait.php', $cacheTime + 5);
+        $this->assertEquals([$route2], $reader->getMethodAnnotations(new ReflectionMethod($className, 'method2')));
+
+        $reader->clearLoadedAnnotations();
+        $this->assertEquals([$route2], $reader->getMethodAnnotations(new ReflectionMethod($className, 'method2')));
+    }
+
+    protected function doTestCacheStale(string $className, int $lastCacheModification): PsrCachedReader
+    {
+        $cacheKey = rawurlencode($className);
+
+        $route          = new Route();
+        $route->pattern = '/someprefix';
+
+        $cacheItem     = $this->createCacheItem($cacheKey, true, []);
+        $timeCacheItem = $this->createCacheItem('[C]' . $cacheKey, true, $lastCacheModification);
+
+        $cache = $this->createMock(CacheItemPoolInterface::class);
+        $cache
+            ->method('getItem')
+            ->willReturnMap([
+                [$cacheKey, $cacheItem],
+                ['[C]' . $cacheKey, $timeCacheItem],
+            ]);
+        $cache
+            ->expects($this->exactly(2))
+            ->method('save')
+            ->withConsecutive([$timeCacheItem], [$cacheItem]);
+
+        $reader = new PsrCachedReader(new AnnotationReader(), $cache, true);
+
+        self::assertEquals([$route], $reader->getClassAnnotations(new ReflectionClass($className)));
+
+        return $reader;
+    }
+
+    protected function doTestCacheFresh(string $className, int $lastCacheModification): void
+    {
+        $cacheKey       = rawurlencode($className);
+        $route          = new Route();
+        $route->pattern = '/someprefix';
+
+        $cacheItem = $this->createMock(CacheItemInterface::class);
+        $cacheItem
+            ->method('isHit')
+            ->willReturn(true);
+        $cacheItem
+            ->method('get')
+            ->willReturn([$route]);
+
+        $timeCacheItem = $this->createMock(CacheItemInterface::class);
+        $timeCacheItem
+            ->method('isHit')
+            ->willReturn(true);
+        $timeCacheItem
+            ->method('get')
+            ->willReturn($lastCacheModification);
+
+        $cache = $this->createMock(CacheItemPoolInterface::class);
+        $cache
+            ->method('getItem')
+            ->willReturnMap([
+                [$cacheKey, $cacheItem],
+                ['[C]' . $cacheKey, $timeCacheItem],
+            ]);
+        $cache->expects(self::never())->method('save');
+        $cache->expects(self::never())->method('commit');
+
+        $reader = new PsrCachedReader(new AnnotationReader(), $cache, true);
+
+        $this->assertEquals([$route], $reader->getClassAnnotations(new ReflectionClass($className)));
+    }
+
+    protected function getReader(): Reader
+    {
+        $this->cache = new ArrayAdapter();
+
+        return new PsrCachedReader(new AnnotationReader(), $this->cache);
+    }
+
+    /** @param mixed $value */
+    private function createCacheItem(string $key, bool $isHit, $value = null): CacheItemInterface
+    {
+        return Closure::bind(
+            static function (string $key, $value, bool $isHit): CacheItem {
+                $item        = new CacheItem();
+                $item->key   = $key;
+                $item->value = $value;
+                $item->isHit = $isHit;
+
+                return $item;
+            },
+            null,
+            CacheItem::class
+        )($key, $value, $isHit);
+    }
+}


### PR DESCRIPTION
This PR adds a `PsrCachedReader` and deprecates the existing CachedReader as doctrine/cache itself will be deprecated in the near future. I've updated documentation to no longer use the deprecated classes (including the `FileCacheReader`) and duplicated existing tests from `CachedReader` to verify functionality.