### PR TITLE
Fix #405

### DIFF
--- a/lib/Doctrine/Common/Annotations/DocParser.php
+++ b/lib/Doctrine/Common/Annotations/DocParser.php
@@ -15,6 +15,7 @@ use stdClass;
 
 use function array_keys;
 use function array_map;
+use function array_pop;
 use function array_values;
 use function class_exists;
 use function constant;
@@ -1424,7 +1425,7 @@ EXCEPTION
             $lastPosition = null;
             foreach ($positions as $position) {
                 if (
-                    ($lastPosition === null && $position !== 0 ) ||
+                    ($lastPosition === null && $position !== 0) ||
                     ($lastPosition !== null && $position !== $lastPosition + 1)
                 ) {
                     throw $this->syntaxError('Positional arguments after named arguments is not allowed');
@@ -1444,7 +1445,7 @@ EXCEPTION
         } else {
             if (count($positionalArguments) > 0 && ! isset($values['value'])) {
                 if (count($positionalArguments) === 1) {
-                    $value = $positionalArguments[0];
+                    $value = array_pop($positionalArguments);
                 } else {
                     $value = array_values($positionalArguments);
                 }

--- a/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
@@ -87,6 +87,24 @@ class DocParserTest extends TestCase
         self::assertInstanceOf(Name::class, $annot->value[0]);
         self::assertInstanceOf(Name::class, $annot->value[1]);
 
+        // Positionals arguments following named arguments
+        $result = $parser->parse('@Name(foo="bar", @Name)');
+        $annot  = $result[0];
+
+        self::assertInstanceOf(Name::class, $annot);
+        self::assertEquals('bar', $annot->foo);
+        self::assertInstanceOf(Name::class, $annot->value);
+
+        // Multiple positionals arguments following named arguments
+        $result = $parser->parse('@Name(@Name, foo="baz", @Name)');
+        $annot  = $result[0];
+
+        self::assertInstanceOf(Name::class, $annot);
+        self::assertEquals('baz', $annot->foo);
+        self::assertIsArray($annot->value);
+        self::assertInstanceOf(Name::class, $annot->value[0]);
+        self::assertInstanceOf(Name::class, $annot->value[1]);
+
         // Multiple scalar values
         $result = $parser->parse('@Name("foo", "bar")');
         $annot  = $result[0];


### PR DESCRIPTION
Fix a bug introduced by my previous PR. 
Positional arguments following named argument should be valid when `@NamedArgumentConstructor` is not used.

Fixes #405 

