### PR TITLE
Improve tests

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -51,6 +51,7 @@
         <exclude-pattern>*/tests/Doctrine/Tests/Common/Annotations/Fixtures/*</exclude-pattern>
     </rule>
     <rule ref="SlevomatCodingStandard.Commenting.ForbiddenAnnotations.AnnotationForbidden">
+        <exclude-pattern>*/tests/Doctrine/Tests/Common/Annotations/AbstractReaderTest.php</exclude-pattern>
         <exclude-pattern>*/tests/Doctrine/Tests/Common/Annotations/Fixtures/*</exclude-pattern>
     </rule>
     <rule ref="SlevomatCodingStandard.Namespaces.UseDoesNotStartWithBackslash.UseStartsWithBackslash">

--- a/tests/Doctrine/Tests/Common/Annotations/AbstractReaderTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/AbstractReaderTest.php
@@ -595,6 +595,7 @@ class TestParseAnnotationClass
 
 /**
  * @Name
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
 class TestIgnoresNonAnnotationsClass
 {

--- a/tests/Doctrine/Tests/Common/Annotations/AbstractReaderTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/AbstractReaderTest.php
@@ -409,9 +409,9 @@ abstract class AbstractReaderTest extends TestCase
 
         $annotation = $reader->getClassAnnotation(
             new ReflectionClass(new TestIgnoresNonAnnotationsClass()),
-            Name::class
+            NameBar::class
         );
-        self::assertInstanceOf(Name::class, $annotation);
+        self::assertInstanceOf(NameBar::class, $annotation);
     }
 
     private static $testResetsPhpParserAfterUseRun = false;
@@ -594,7 +594,7 @@ class TestParseAnnotationClass
 }
 
 /**
- * @Name
+ * @NameBar
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
 class TestIgnoresNonAnnotationsClass
@@ -667,6 +667,10 @@ class DummyClass2
     public $id;
 }
 
+/** @Annotation */
+class NameBar extends Annotation
+{
+}
 /** @Annotation */
 class DummyId extends Annotation
 {


### PR DESCRIPTION
AbstractReaderTest relied on an annotation defined in DocParserTest. As
a consequence, running extending tests by themselves failed.