### PR TITLE
Don't hit the reader if cache is fresh

### DIFF
--- a/lib/Doctrine/Common/Annotations/PsrCachedReader.php
+++ b/lib/Doctrine/Common/Annotations/PsrCachedReader.php
@@ -151,7 +151,7 @@ final class PsrCachedReader implements Reader
         $cacheKey = rawurlencode($cacheKey);
 
         $item = $this->cache->getItem($cacheKey);
-        if (! $item->isHit() || ($this->debug && ! $this->refresh($cacheKey, $class))) {
+        if (($this->debug && ! $this->refresh($cacheKey, $class)) || ! $item->isHit()) {
             $this->cache->save($item->set($this->delegate->{$method}($reflector)));
         }
 


### PR DESCRIPTION
Spotted while working on symfony/symfony#41230.

In debug mode, the `PsrCachedReader` hits the wrapped reader although the cache is still fresh. This happens because the cache items that stores the modification date is not written initially. This PR attempts to fix this problem.