### PR TITLE
Update Eclipse Symfony 2 Plugin link in docs

### DIFF
--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -94,7 +94,7 @@ IDE Support
 
 Some IDEs already provide support for annotations:
 
-- Eclipse via the `Symfony2 Plugin <http://symfony.dubture.com/>`_
+- Eclipse via the `Symfony2 Plugin <https://github.com/pulse00/Symfony-2-Eclipse-Plugin>`_
 - PhpStorm via the `PHP Annotations Plugin <https://plugins.jetbrains.com/plugin/7320-php-annotations>`_ or the `Symfony Plugin <https://plugins.jetbrains.com/plugin/7219-symfony-support>`_
 
 .. _Read more about handling annotations.: annotations


### PR DESCRIPTION
The url dubture.com is down (unknown reason). Pointing to github repository

Alternatives:
https://github.com/pulse00/Symfony-2-Eclipse-Plugin/
https://marketplace.eclipse.org/content/symfony-plugin