### PR TITLE
Add NamedArgumentConstructor to reserved annotations

### DIFF
--- a/lib/Doctrine/Common/Annotations/ImplicitlyIgnoredAnnotationNames.php
+++ b/lib/Doctrine/Common/Annotations/ImplicitlyIgnoredAnnotationNames.php
@@ -12,12 +12,13 @@ namespace Doctrine\Common\Annotations;
 final class ImplicitlyIgnoredAnnotationNames
 {
     private const Reserved = [
-        'Annotation' => true,
-        'Attribute'  => true,
-        'Attributes' => true,
+        'Annotation'               => true,
+        'Attribute'                => true,
+        'Attributes'               => true,
         /* Can we enable this? 'Enum' => true, */
-        'Required'   => true,
-        'Target'     => true,
+        'Required'                 => true,
+        'Target'                   => true,
+        'NamedArgumentConstructor' => true,
     ];
 
     private const WidelyUsedNonStandard = [


### PR DESCRIPTION
When introducing the `NamedArgumentConstructor` annotation, I accidentally created the edge-case of acore annotation that needs to be imported. This is not the case for other core annotations like `Annotation` or `Target`. This PR attempts to fix that.