### PR TITLE
Add psalm annotations to ignored annotation name

### DIFF
--- a/lib/Doctrine/Common/Annotations/ImplicitlyIgnoredAnnotationNames.php
+++ b/lib/Doctrine/Common/Annotations/ImplicitlyIgnoredAnnotationNames.php
@@ -139,16 +139,21 @@ final class ImplicitlyIgnoredAnnotationNames
 
     private const SlevomatCodingStandard = ['phpcsSuppress' => true];
 
-    private const PhpStan = [
+    private const Phan = ['suppress' => true];
+
+    private const Rector = ['noRector' => true];
+
+    private const StaticAnalysis = [
+        // PHPStan, Psalm
         'extends' => true,
         'implements' => true,
         'template' => true,
         'use' => true,
+
+        // Psalm
+        'pure' => true,
+        'immutable' => true,
     ];
-
-    private const Phan = ['suppress' => true];
-
-    private const Rector = ['noRector' => true];
 
     public const LIST = self::Reserved
         + self::WidelyUsedNonStandard
@@ -162,9 +167,9 @@ final class ImplicitlyIgnoredAnnotationNames
         + self::Symfony
         + self::SlevomatCodingStandard
         + self::PhpCodeSniffer
-        + self::PhpStan
         + self::Phan
-        + self::Rector;
+        + self::Rector
+        + self::StaticAnalysis;
 
     private function __construct()
     {


### PR DESCRIPTION
@pure annotation is mainly used by psalm to mark pure functions.