### PR TITLE
updated .doctrine-project.json

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -5,21 +5,39 @@
     "docsSlug": "doctrine-annotations",
     "versions": [
         {
-            "name": "1.11",
-            "branchName": "master",
+            "name": "1.14",
+            "branchName": "1.14.x",
             "slug": "latest",
             "upcoming": true
         },
         {
-            "name": "1.10",
-            "branchName": "1.10.x",
-            "slug": "1.10",
+            "name": "1.13",
+            "branchName": "1.13.x",
+            "slug": "1.13",
             "aliases": [
                 "current",
                 "stable"
             ],
             "current": true,
             "maintained": true
+        },
+        {
+            "name": "1.12",
+            "branchName": "1.12.x",
+            "slug": "1.12",
+            "maintained": false
+        },
+        {
+            "name": "1.11",
+            "branchName": "1.11.x",
+            "slug": "1.11",
+            "maintained": false
+        },
+        {
+            "name": "1.10",
+            "branchName": "1.10.x",
+            "slug": "1.10",
+            "maintained": false
         },
         {
             "name": "1.9",


### PR DESCRIPTION
It looks like the `.doctrine-project.json` hasn't been updated for a while. This leads to the annotation's website looking a bit weird: https://www.doctrine-project.org/projects/annotations.html

 - 1.13.2 ➔ unmaintained
 - 1.12.1 ➔ unmaintained
 - 1.11.2 ➔ stable
 - 1.10.4 ➔ stable

This PR updates `.doctrine-project.json` to reflect the current branches and releases.
