### PR TITLE
added non-static ignoredNamespace config for Reader

### DIFF
--- a/lib/Doctrine/Common/Annotations/AnnotationReader.php
+++ b/lib/Doctrine/Common/Annotations/AnnotationReader.php
@@ -67,6 +67,15 @@ class AnnotationReader implements Reader
     }
 
     /**
+     * A list with annotation namespaces that are not causing exceptions when not resolved to an annotation class.
+     *
+     * The names are case sensitive.
+     *
+     * @var array<string, true>
+     */
+    private $ignoredNamespaces = [];
+
+    /**
      * Annotations parser.
      *
      * @var DocParser
@@ -134,6 +143,14 @@ class AnnotationReader implements Reader
     }
 
     /**
+     * Add a new annotation to the ignored annotation namespaces with regard to exception handling.
+     */
+    final public function addIgnoredNamespace(string $namespace): void
+    {
+        $this->ignoredNamespaces[$namespace] = true;
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function getClassAnnotations(ReflectionClass $class)
@@ -141,7 +158,7 @@ class AnnotationReader implements Reader
         $this->parser->setTarget(Target::TARGET_CLASS);
         $this->parser->setImports($this->getImports($class));
         $this->parser->setIgnoredAnnotationNames($this->getIgnoredAnnotationNames($class));
-        $this->parser->setIgnoredAnnotationNamespaces(self::$globalIgnoredNamespaces);
+        $this->parser->setIgnoredAnnotationNamespaces($this->getIgnoredNamespaces());
 
         return $this->parser->parse($class->getDocComment(), 'class ' . $class->getName());
     }
@@ -173,7 +190,7 @@ class AnnotationReader implements Reader
         $this->parser->setTarget(Target::TARGET_PROPERTY);
         $this->parser->setImports($this->getPropertyImports($property));
         $this->parser->setIgnoredAnnotationNames($this->getIgnoredAnnotationNames($class));
-        $this->parser->setIgnoredAnnotationNamespaces(self::$globalIgnoredNamespaces);
+        $this->parser->setIgnoredAnnotationNamespaces($this->getIgnoredNamespaces());
 
         return $this->parser->parse($property->getDocComment(), $context);
     }
@@ -205,7 +222,7 @@ class AnnotationReader implements Reader
         $this->parser->setTarget(Target::TARGET_METHOD);
         $this->parser->setImports($this->getMethodImports($method));
         $this->parser->setIgnoredAnnotationNames($this->getIgnoredAnnotationNames($class));
-        $this->parser->setIgnoredAnnotationNamespaces(self::$globalIgnoredNamespaces);
+        $this->parser->setIgnoredAnnotationNamespaces($this->getIgnoredNamespaces());
 
         return $this->parser->parse($method->getDocComment(), $context);
     }
@@ -238,7 +255,7 @@ class AnnotationReader implements Reader
         $this->parser->setTarget(Target::TARGET_FUNCTION);
         $this->parser->setImports($this->getImports($function));
         $this->parser->setIgnoredAnnotationNames($this->getIgnoredAnnotationNames($function));
-        $this->parser->setIgnoredAnnotationNamespaces(self::$globalIgnoredNamespaces);
+        $this->parser->setIgnoredAnnotationNamespaces($this->getIgnoredNamespaces());
 
         return $this->parser->parse($function->getDocComment(), $context);
     }
@@ -385,5 +402,15 @@ class AnnotationReader implements Reader
         );
 
         $this->ignoredAnnotationNames[$type][$name] = $ignoredAnnotationNames;
+    }
+
+    /**
+     * Returns the ignored annotation namespaces, merging the global static namespaces with the private ones
+     *
+     * @return array<string, true>
+     */
+    private function getIgnoredNamespaces(): array
+    {
+        return array_merge(self::$globalIgnoredNamespaces, $this->ignoredNamespaces);
     }
 }

--- a/tests/Doctrine/Tests/Common/Annotations/AnnotationReaderTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/AnnotationReaderTest.php
@@ -144,12 +144,12 @@ class AnnotationReaderTest extends AbstractReaderTest
      * @group 45
      * @runInSeparateProcess
      */
-    public function testClassAnnotationIsIgnored(): void
+    public function testClassAnnotationIsIgnoredByGlobalName(): void
     {
         $reader = $this->getReader();
         $ref    = new ReflectionClass(AnnotatedAtClassLevel::class);
 
-        $reader::addGlobalIgnoredNamespace('SomeClassAnnotationNamespace');
+        $reader::addGlobalIgnoredName('SomeClassAnnotationNamespace\\Subnamespace\\Name');
 
         self::assertEmpty($reader->getClassAnnotations($ref));
     }
@@ -158,12 +158,52 @@ class AnnotationReaderTest extends AbstractReaderTest
      * @group 45
      * @runInSeparateProcess
      */
-    public function testMethodAnnotationIsIgnored(): void
+    public function testClassAnnotationIsIgnoredByGlobalNamespace(): void
+    {
+        $reader = $this->getReader();
+        $ref    = new ReflectionClass(AnnotatedAtClassLevel::class);
+
+        $reader::addGlobalIgnoredNamespace('SomeClassAnnotationNamespace');
+
+        self::assertEmpty($reader->getClassAnnotations($ref));
+
+        $reader->addIgnoredNamespace('FooBar');
+
+        self::assertEmpty($reader->getClassAnnotations($ref));
+    }
+
+    /**
+     * @group 45
+     * @runInSeparateProcess
+     */
+    public function testClassAnnotationIsIgnoredByNamespace(): void
+    {
+        $reader = $this->getReader();
+        $ref    = new ReflectionClass(AnnotatedAtClassLevel::class);
+
+        $reader->addIgnoredNamespace('SomeClassAnnotationNamespace');
+
+        self::assertEmpty($reader->getClassAnnotations($ref));
+
+        $reader::addGlobalIgnoredNamespace('fooBar');
+
+        self::assertEmpty($reader->getClassAnnotations($ref));
+    }
+
+    /**
+     * @group 45
+     * @runInSeparateProcess
+     */
+    public function testMethodAnnotationIsIgnoredByGlobalNamespace(): void
     {
         $reader = $this->getReader();
         $ref    = new ReflectionClass(AnnotatedAtMethodLevel::class);
 
         $reader::addGlobalIgnoredNamespace('SomeMethodAnnotationNamespace');
+
+        self::assertEmpty($reader->getMethodAnnotations($ref->getMethod('test')));
+
+        $reader->addIgnoredNamespace('FooBar');
 
         self::assertEmpty($reader->getMethodAnnotations($ref->getMethod('test')));
     }
@@ -172,12 +212,52 @@ class AnnotationReaderTest extends AbstractReaderTest
      * @group 45
      * @runInSeparateProcess
      */
-    public function testPropertyAnnotationIsIgnored(): void
+    public function testMethodAnnotationIsIgnoredByNamespace(): void
+    {
+        $reader = $this->getReader();
+        $ref    = new ReflectionClass(AnnotatedAtMethodLevel::class);
+
+        $reader->addIgnoredNamespace('SomeMethodAnnotationNamespace');
+
+        self::assertEmpty($reader->getMethodAnnotations($ref->getMethod('test')));
+
+        $reader::addGlobalIgnoredNamespace('fooBar');
+
+        self::assertEmpty($reader->getMethodAnnotations($ref->getMethod('test')));
+    }
+
+    /**
+     * @group 45
+     * @runInSeparateProcess
+     */
+    public function testPropertyAnnotationIsIgnoredByGlobalNamespace(): void
     {
         $reader = $this->getReader();
         $ref    = new ReflectionClass(AnnotatedAtPropertyLevel::class);
 
         $reader::addGlobalIgnoredNamespace('SomePropertyAnnotationNamespace');
+
+        self::assertEmpty($reader->getPropertyAnnotations($ref->getProperty('property')));
+
+        $reader->addIgnoredNamespace('fooBar');
+
+        self::assertEmpty($reader->getPropertyAnnotations($ref->getProperty('property')));
+    }
+
+    /**
+     * @group 45
+     * @runInSeparateProcess
+     */
+    public function testPropertyAnnotationIsIgnoredByNamespace(): void
+    {
+        $reader = $this->getReader();
+        $ref    = new ReflectionClass(AnnotatedAtPropertyLevel::class);
+
+        $reader->addIgnoredNamespace('SomePropertyAnnotationNamespace');
+
+        self::assertEmpty($reader->getPropertyAnnotations($ref->getProperty('property')));
+
+        $reader::addGlobalIgnoredNamespace('fooBar');
 
         self::assertEmpty($reader->getPropertyAnnotations($ref->getProperty('property')));
     }
@@ -186,12 +266,34 @@ class AnnotationReaderTest extends AbstractReaderTest
      * @group 244
      * @runInSeparateProcess
      */
-    public function testAnnotationWithAliasIsIgnored(): void
+    public function testAnnotationWithAliasIsIgnoredByGlobalNamespace(): void
     {
         $reader = $this->getReader();
         $ref    = new ReflectionClass(AnnotatedWithAlias::class);
 
         $reader::addGlobalIgnoredNamespace('SomePropertyAnnotationNamespace');
+
+        self::assertEmpty($reader->getPropertyAnnotations($ref->getProperty('property')));
+
+        $reader->addIgnoredNamespace('fooBar');
+
+        self::assertEmpty($reader->getPropertyAnnotations($ref->getProperty('property')));
+    }
+
+    /**
+     * @group 244
+     * @runInSeparateProcess
+     */
+    public function testAnnotationWithAliasIsIgnoredByNamespace(): void
+    {
+        $reader = $this->getReader();
+        $ref    = new ReflectionClass(AnnotatedWithAlias::class);
+
+        $reader->addIgnoredNamespace('SomePropertyAnnotationNamespace');
+
+        self::assertEmpty($reader->getPropertyAnnotations($ref->getProperty('property')));
+
+        $reader::addGlobalIgnoredNamespace('fooBar');
 
         self::assertEmpty($reader->getPropertyAnnotations($ref->getProperty('property')));
     }


### PR DESCRIPTION
In light of the discussion of https://github.com/doctrine/annotations/pull/426 I created this PR to allow per-Reader instance configuration of ignored namespaces.
The static configuration is kept for BC compatibility and tests are added mixing static and private configuration.