### PR TITLE
#186 check if file exists before asking for mtime

### DIFF
--- a/lib/Doctrine/Common/Annotations/CachedReader.php
+++ b/lib/Doctrine/Common/Annotations/CachedReader.php
@@ -10,7 +10,9 @@ use ReflectionProperty;
 use function array_map;
 use function array_merge;
 use function assert;
+use function file_exists;
 use function filemtime;
+use function is_file;
 use function max;
 use function time;
 
@@ -231,7 +233,7 @@ final class CachedReader implements Reader
         $parent = $class->getParentClass();
 
         $lastModification =  max(array_merge(
-            [$filename ? filemtime($filename) : 0],
+            [self::getFileMtime($filename)],
             array_map(function (ReflectionClass $reflectionTrait): int {
                 return $this->getTraitLastModificationTime($reflectionTrait);
             }, $class->getTraits()),
@@ -255,7 +257,7 @@ final class CachedReader implements Reader
         }
 
         $lastModificationTime = max(array_merge(
-            [$fileName ? filemtime($fileName) : 0],
+            [self::getFileMtime($fileName)],
             array_map(function (ReflectionClass $reflectionTrait): int {
                 return $this->getTraitLastModificationTime($reflectionTrait);
             }, $reflectionTrait->getTraits())
@@ -264,5 +266,10 @@ final class CachedReader implements Reader
         assert($lastModificationTime !== false);
 
         return $this->loadedFilemtimes[$fileName] = $lastModificationTime;
+    }
+
+    private static function getFileMtime(string $fileName): int
+    {
+        return file_exists($fileName) && is_file($fileName) ? filemtime($fileName) : 0;
     }
 }

--- a/lib/Doctrine/Common/Annotations/PsrCachedReader.php
+++ b/lib/Doctrine/Common/Annotations/PsrCachedReader.php
@@ -195,7 +195,7 @@ final class PsrCachedReader implements Reader
         $parent = $class->getParentClass();
 
         $lastModification =  max(array_merge(
-            [$filename ? filemtime($filename) : 0],
+            [self::getFileMtime($filename)],
             array_map(function (ReflectionClass $reflectionTrait): int {
                 return $this->getTraitLastModificationTime($reflectionTrait);
             }, $class->getTraits()),
@@ -219,7 +219,7 @@ final class PsrCachedReader implements Reader
         }
 
         $lastModificationTime = max(array_merge(
-            [$fileName ? filemtime($fileName) : 0],
+            [self::getFileMtime($fileName)],
             array_map(function (ReflectionClass $reflectionTrait): int {
                 return $this->getTraitLastModificationTime($reflectionTrait);
             }, $reflectionTrait->getTraits())
@@ -228,5 +228,10 @@ final class PsrCachedReader implements Reader
         assert($lastModificationTime !== false);
 
         return $this->loadedFilemtimes[$fileName] = $lastModificationTime;
+    }
+
+    private static function getFileMtime(string $fileName): int
+    {
+        return file_exists($fileName) && is_file($fileName) ? filemtime($fileName) : 0;
     }
 }

--- a/tests/Doctrine/Tests/Common/Annotations/PsrCachedReaderTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/PsrCachedReaderTest.php
@@ -220,6 +220,27 @@ final class PsrCachedReaderTest extends AbstractReaderTest
         );
     }
 
+    public function testReaderDoesNotCacheIfFileDoesNotExistSoLastModificationCannotBeDetermined(): void
+    {
+        $code = <<<'EOS'
+namespace Doctrine\Tests\Common\Annotations;
+
+/**
+ * @\Doctrine\Tests\Common\Annotations\Fixtures\AnnotationTargetClass("Some data")
+ */
+class PsrEvalClass {
+
+}
+EOS;
+
+        eval($code);
+
+        $readAnnotations = (new PsrCachedReader(new AnnotationReader(), new ArrayAdapter(), true))
+            ->getClassAnnotations(new ReflectionClass(PsrEvalClass::class));
+
+        self::assertCount(1, $readAnnotations);
+    }
+
     protected function doTestCacheStale(string $className, int $lastCacheModification): PsrCachedReader
     {
         $cacheKey = rawurlencode($className);


### PR DESCRIPTION
`doctrine/annotations` handles reading annotations from eval’ed code (as in mock objects) just fine, except that it attempts to determine the modification time via `ReflectionClass::getFile()` which will return the file and line where the `eval()` happened. This change adds fix and test for the `PsrCachedReader` and also fixes `CachedReader` but without a tests since it’s deprecated.

Fixes #186 