### PR TITLE
Whitelist necessary plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,10 @@
         "vimeo/psalm": "^4.10"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     },
     "autoload": {
         "psr-4": { "Doctrine\\Common\\Annotations\\": "lib/Doctrine/Common/Annotations" }


### PR DESCRIPTION
Not doing so results in the coding standard job to fail.