### PR TITLE
Bump dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,10 +39,10 @@
     },
     "require-dev": {
         "doctrine/cache": "^1.11 || ^2.0",
-        "doctrine/coding-standard": "^6.0 || ^8.1",
-        "phpstan/phpstan": "^1.4.10 || ^1.8.0",
-        "phpunit/phpunit": "^7.5 || ^8.0 || ^9.1.5",
-        "symfony/cache": "^4.4 || ^5.2",
+        "doctrine/coding-standard": "^9",
+        "phpstan/phpstan": "~1.4.10 || ^1.8.0",
+        "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+        "symfony/cache": "^4.4 || ^5.4 || ^6",
         "vimeo/psalm": "^4.10"
     },
     "autoload": {

--- a/lib/Doctrine/Common/Annotations/Annotation/Enum.php
+++ b/lib/Doctrine/Common/Annotations/Annotation/Enum.php
@@ -34,9 +34,9 @@ final class Enum
     public $literal;
 
     /**
-     * @throws InvalidArgumentException
-     *
      * @phpstan-param array{literal?: mixed[], value: list<scalar>} $values
+     *
+     * @throws InvalidArgumentException
      */
     public function __construct(array $values)
     {

--- a/lib/Doctrine/Common/Annotations/Annotation/IgnoreAnnotation.php
+++ b/lib/Doctrine/Common/Annotations/Annotation/IgnoreAnnotation.php
@@ -21,9 +21,9 @@ final class IgnoreAnnotation
     public $names;
 
     /**
-     * @throws RuntimeException
-     *
      * @phpstan-param array{value: string|list<string>} $values
+     *
+     * @throws RuntimeException
      */
     public function __construct(array $values)
     {

--- a/lib/Doctrine/Common/Annotations/Annotation/Target.php
+++ b/lib/Doctrine/Common/Annotations/Annotation/Target.php
@@ -56,9 +56,9 @@ final class Target
     public $literal;
 
     /**
-     * @throws InvalidArgumentException
-     *
      * @phpstan-param array{value?: string|list<string>} $values
+     *
+     * @throws InvalidArgumentException
      */
     public function __construct(array $values)
     {

--- a/lib/Doctrine/Common/Annotations/AnnotationException.php
+++ b/lib/Doctrine/Common/Annotations/AnnotationException.php
@@ -133,10 +133,9 @@ class AnnotationException extends Exception
      * @param string $annotationName
      * @param string $context
      * @param mixed  $given
+     * @phpstan-param list<string>        $available
      *
      * @return AnnotationException
-     *
-     * @phpstan-param list<string>        $available
      */
     public static function enumeratorError($attributeName, $annotationName, $context, $available, $given)
     {

--- a/lib/Doctrine/Common/Annotations/DocParser.php
+++ b/lib/Doctrine/Common/Annotations/DocParser.php
@@ -357,10 +357,10 @@ final class DocParser
      * @param string $input   The docblock string to parse.
      * @param string $context The parsing context.
      *
+     * @phpstan-return list<object> Array of annotations. If no annotations are found, an empty array is returned.
+     *
      * @throws AnnotationException
      * @throws ReflectionException
-     *
-     * @phpstan-return list<object> Array of annotations. If no annotations are found, an empty array is returned.
      */
     public function parse($input, $context = '')
     {
@@ -426,9 +426,9 @@ final class DocParser
      * If any of them matches, this method updates the lookahead token; otherwise
      * a syntax error is raised.
      *
-     * @throws AnnotationException
-     *
      * @phpstan-param list<mixed[]> $tokens
+     *
+     * @throws AnnotationException
      */
     private function matchAny(array $tokens): bool
     {
@@ -674,10 +674,10 @@ final class DocParser
     /**
      * Annotations ::= Annotation {[ "*" ]* [Annotation]}*
      *
+     * @phpstan-return list<object>
+     *
      * @throws AnnotationException
      * @throws ReflectionException
-     *
-     * @phpstan-return list<object>
      */
     private function Annotations(): array
     {
@@ -1357,10 +1357,10 @@ EXCEPTION
      * KeyValuePair ::= Key ("=" | ":") PlainValue | Constant
      * Key ::= string | integer | Constant
      *
+     * @phpstan-return array{mixed, mixed}
+     *
      * @throws AnnotationException
      * @throws ReflectionException
-     *
-     * @phpstan-return array{mixed, mixed}
      */
     private function ArrayEntry(): array
     {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -12,6 +12,8 @@
     <!-- Show progress of the run and show sniff names -->
     <arg value="ps"/>
 
+    <config name="php_version" value="70100"/>
+
     <file>lib</file>
     <file>tests</file>
 
@@ -103,16 +105,6 @@
         <exclude-pattern>*/tests/Doctrine/Tests/Common/Annotations/PhpParserTest.php</exclude-pattern>
         <exclude-pattern>*/tests/Doctrine/Tests/Common/Annotations/Fixtures/NamespaceWithClosureDeclaration.php</exclude-pattern>
         <exclude-pattern>*/tests/Doctrine/Tests/Common/Annotations/Fixtures/ClassWithRequire.php</exclude-pattern>
-    </rule>
-
-    <!-- these classes have unused properties, and is unused in a benchmark for the parser -->
-    <rule ref="SlevomatCodingStandard.Classes.UnusedPrivateElements.UnusedProperty">
-        <exclude-pattern>*/tests/Doctrine/Tests/Common/Annotations/Fixtures/SingleClassLOC1000.php</exclude-pattern>
-        <exclude-pattern>*/tests/Doctrine/Tests/Common/Annotations/Fixtures/NamespacedSingleClassLOC1000.php</exclude-pattern>
-    </rule>
-
-    <rule ref="SlevomatCodingStandard.Classes.UnusedPrivateElements.UnusedMethod">
-        <exclude-pattern>*/tests/Doctrine/Tests/Common/Annotations/Fixtures/Controller.php</exclude-pattern>
     </rule>
 
     <!-- these classes do not have a namespace on purpose -->


### PR DESCRIPTION
This PR bumps a couple of dev dependencies. Most notably, the Doctrine CS is bumped to 9.0 which results in a couple of doc blocks being reformatted.