### PR TITLE
Convert ini_get result to bool before evaluating

### DIFF
--- a/lib/Doctrine/Common/Annotations/AnnotationReader.php
+++ b/lib/Doctrine/Common/Annotations/AnnotationReader.php
@@ -9,10 +9,13 @@ use ReflectionFunction;
 use ReflectionMethod;
 use ReflectionProperty;
 
+use const FILTER_VALIDATE_BOOLEAN;
+
+use function extension_loaded;
 use function array_merge;
 use function class_exists;
-use function extension_loaded;
 use function ini_get;
+use function filter_var;
 
 /**
  * A reader for docblock annotations.
@@ -109,13 +112,15 @@ class AnnotationReader implements Reader
     public function __construct(?DocParser $parser = null)
     {
         if (
-            extension_loaded('Zend Optimizer+') && (filter_var(ini_get('zend_optimizerplus.save_comments'),FILTER_VALIDATE_BOOLEAN)  === false ||
-            filter_var(ini_get('opcache.save_comments'),FILTER_VALIDATE_BOOLEAN) === false)
+            extension_loaded('Zend Optimizer+') &&
+            (filter_var(ini_get('zend_optimizerplus.save_comments'), FILTER_VALIDATE_BOOLEAN)  === false ||
+            filter_var(ini_get('opcache.save_comments'), FILTER_VALIDATE_BOOLEAN) === false)
         ) {
             throw AnnotationException::optimizerPlusSaveComments();
         }
 
-        if (extension_loaded('Zend OPcache') && filter_var(ini_get('opcache.save_comments'), FILTER_VALIDATE_BOOLEAN) === false) {
+        if (extension_loaded('Zend OPcache') &&
+            filter_var(ini_get('opcache.save_comments'), FILTER_VALIDATE_BOOLEAN) === false) {
             throw AnnotationException::optimizerPlusSaveComments();
         }
 

--- a/lib/Doctrine/Common/Annotations/AnnotationReader.php
+++ b/lib/Doctrine/Common/Annotations/AnnotationReader.php
@@ -109,13 +109,13 @@ class AnnotationReader implements Reader
     public function __construct(?DocParser $parser = null)
     {
         if (
-            extension_loaded('Zend Optimizer+') && (ini_get('zend_optimizerplus.save_comments') === '0' ||
-            ini_get('opcache.save_comments') === '0')
+            extension_loaded('Zend Optimizer+') && (filter_var(ini_get('zend_optimizerplus.save_comments'),FILTER_VALIDATE_BOOLEAN)  === false ||
+            filter_var(ini_get('opcache.save_comments'),FILTER_VALIDATE_BOOLEAN) === false)
         ) {
             throw AnnotationException::optimizerPlusSaveComments();
         }
 
-        if (extension_loaded('Zend OPcache') && ini_get('opcache.save_comments') === 0) {
+        if (extension_loaded('Zend OPcache') && filter_var(ini_get('opcache.save_comments'), FILTER_VALIDATE_BOOLEAN) === false) {
             throw AnnotationException::optimizerPlusSaveComments();
         }
 


### PR DESCRIPTION
ini_get returns a string, so checking === 0 won't work.
Convert ini_get result to bool before evaluating. 
FILTER_VALIDATE_BOOLEAN will return true for ["1", "true", "on" and "yes"] and false for ["0", "false", "off" and "no"]