### PR TITLE
Check DocParser::PlainValue for false return value

### DIFF
--- a/lib/Doctrine/Common/Annotations/DocParser.php
+++ b/lib/Doctrine/Common/Annotations/DocParser.php
@@ -1239,7 +1239,11 @@ EXCEPTION
         }
 
         if ($this->lexer->isNextToken(DocLexer::T_AT)) {
-            return $this->Annotation();
+            $annotation = $this->Annotation();
+            if ($annotation === false) {
+                return null;
+            }
+            return $annotation;
         }
 
         if ($this->lexer->isNextToken(DocLexer::T_IDENTIFIER)) {
@@ -1341,6 +1345,10 @@ EXCEPTION
 
         foreach ($values as $value) {
             [$key, $val] = $value;
+
+            if ($key === null && $val === null) {
+                continue;
+            }
 
             if ($key !== null) {
                 $array[$key] = $val;


### PR DESCRIPTION
`DocParser::PlainValue` always returns the result of `DocParser::Annotation`, even if it returns false because of an invalid/ignored annotation. `DocParser::Annotations` on the contrary checks the return value and returns early if it's false, actually ignoring the annotation, which seems like the right behaviour.

This causes an issue where a nested annotation in an ignored namespace appears in the parsing result as false, breaking Symfony validation with the following error:

`
An error occurred while instantiating the annotation @Assert\Collection declared on property SomeClass::$someProperty: "The value "" is not an instance of Constraint in constraint "Symfony\Component\Validator\Constraints\Required".".
`