### PR TITLE
Added support for backed enum

### DIFF
--- a/lib/Doctrine/Common/Annotations/DocParser.php
+++ b/lib/Doctrine/Common/Annotations/DocParser.php
@@ -426,7 +426,7 @@ final class DocParser
      * If any of them matches, this method updates the lookahead token; otherwise
      * a syntax error is raised.
      *
-     * @phpstan-param list<int|string> $tokens
+     * @phpstan-param list<mixed[]> $tokens
      *
      * @throws AnnotationException
      */

--- a/lib/Doctrine/Common/Annotations/DocParser.php
+++ b/lib/Doctrine/Common/Annotations/DocParser.php
@@ -1157,7 +1157,7 @@ EXCEPTION
 
 		/** @noinspection PhpElementIsNotAvailableInCurrentPhpVersionInspection */
 		if (interface_exists('\UnitEnum') && $value instanceof \UnitEnum) {
-			if (!property_exists($value, 'value')) {
+			if (!interface_exists('\BackedEnum') || !($value instanceof \BackedEnum)) {
 				throw AnnotationException::semanticalErrorConstants('Enum ' . $identifier. ' is not backed enum, only backed enums can be used!');
 			}
 			$value = $value->value;

--- a/lib/Doctrine/Common/Annotations/DocParser.php
+++ b/lib/Doctrine/Common/Annotations/DocParser.php
@@ -426,7 +426,7 @@ final class DocParser
      * If any of them matches, this method updates the lookahead token; otherwise
      * a syntax error is raised.
      *
-     * @phpstan-param list<mixed[]> $tokens
+     * @phpstan-param list<int|string> $tokens
      *
      * @throws AnnotationException
      */
@@ -1153,7 +1153,17 @@ EXCEPTION
             throw AnnotationException::semanticalErrorConstants($identifier, $this->context);
         }
 
-        return constant($identifier);
+		$value = constant($identifier);
+
+		/** @noinspection PhpElementIsNotAvailableInCurrentPhpVersionInspection */
+		if (interface_exists('\UnitEnum') && $value instanceof \UnitEnum) {
+			if (!property_exists($value, 'value')) {
+				throw AnnotationException::semanticalErrorConstants('Enum ' . $identifier. ' is not backed enum, only backed enums can be used!');
+			}
+			$value = $value->value;
+		}
+
+        return $value;
     }
 
     private function identifierStartsWithBackslash(string $identifier): bool


### PR DESCRIPTION
In php 8.1 support for enums was added.

Currently, if enum case is used instead of constant, annotations fail with unintuitive message, such as
`Fatal error: Uncaught TypeError: Illegal offset type in /data/vendor/doctrine/annotations/lib/Doctrine/Common/Annotations/DocParser.php on line 1357`.

This PR adds support for usage of backend enums in annotations (used same as class constants), and throws exception in case non-backed enum is used (which cannot be easily converted to int/string ).
