### PR TITLE
Bump GHA workflows

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -12,4 +12,4 @@ on:
 jobs:
   coding-standards:
     name: "Coding Standards"
-    uses: "doctrine/.github/.github/workflows/coding-standards.yml@1.5.1"
+    uses: "doctrine/.github/.github/workflows/coding-standards.yml@2.1.0"

--- a/.github/workflows/composer-lint.yml
+++ b/.github/workflows/composer-lint.yml
@@ -15,4 +15,4 @@ on:
 jobs:
   composer-lint:
     name: "Composer Lint"
-    uses: "doctrine/.github/.github/workflows/composer-lint.yml@1.5.1"
+    uses: "doctrine/.github/.github/workflows/composer-lint.yml@2.1.0"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -14,6 +14,6 @@ env:
 jobs:
   phpunit:
     name: "PHPUnit"
-    uses: "doctrine/.github/.github/workflows/continuous-integration.yml@1.5.1"
+    uses: "doctrine/.github/.github/workflows/continuous-integration.yml@2.1.0"
     with:
-      php-versions: '["7.1", "7.2", "7.3", "7.4", "8.0"]'
+      php-versions: '["7.1", "7.2", "7.3", "7.4", "8.0", "8.1", "8.2"]'

--- a/.github/workflows/release-on-milestone-closed.yml
+++ b/.github/workflows/release-on-milestone-closed.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   release:
     name: "Git tag, release & create merge-up PR"
-    uses: "doctrine/.github/.github/workflows/release-on-milestone-closed.yml@1.5.1"
+    uses: "doctrine/.github/.github/workflows/release-on-milestone-closed.yml@2.1.0"
     secrets:
       GIT_AUTHOR_EMAIL: ${{ secrets.GIT_AUTHOR_EMAIL }}
       GIT_AUTHOR_NAME: ${{ secrets.GIT_AUTHOR_NAME }}

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -12,4 +12,4 @@ on:
 jobs:
   static-analysis:
     name: "Static Analysis"
-    uses: "doctrine/.github/.github/workflows/static-analysis.yml@1.5.1"
+    uses: "doctrine/.github/.github/workflows/static-analysis.yml@2.1.0"


### PR DESCRIPTION
This PR bumps all CI workflows and adds PHP 8.1 (!) and 8.2 to the build matrix.