### PR TITLE
Added test cases for enums

### DIFF
--- a/tests/Doctrine/Tests/Common/Annotations/Fixtures/AnnotationWithEnumProperty.php
+++ b/tests/Doctrine/Tests/Common/Annotations/Fixtures/AnnotationWithEnumProperty.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Common\Annotations\Fixtures;
+
+/**
+ * @Annotation
+ * @Target("ALL")
+ * @NamedArgumentConstructor
+ */
+final class AnnotationWithEnumProperty
+{
+    public function __construct(
+        public readonly Suit $suit = Suit::Hearts,
+    ) {
+    }
+}

--- a/tests/Doctrine/Tests/Common/Annotations/Fixtures/ClassWithEnumAnnotations.php
+++ b/tests/Doctrine/Tests/Common/Annotations/Fixtures/ClassWithEnumAnnotations.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Common\Annotations\Fixtures;
+
+class ClassWithEnumAnnotations
+{
+    /** @AnnotationWithEnumProperty */
+    public mixed $annotationWithDefaults;
+
+    /** @AnnotationWithEnumProperty(suit=Suit::Spades) */
+    public mixed $annotationWithSpades;
+}

--- a/tests/Doctrine/Tests/Common/Annotations/Fixtures/Suit.php
+++ b/tests/Doctrine/Tests/Common/Annotations/Fixtures/Suit.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Common\Annotations\Fixtures;
+
+enum Suit
+{
+    case Hearts;
+    case Diamonds;
+    case Clubs;
+    case Spades;
+}


### PR DESCRIPTION
By coincidence, we already support enums in annotations. Let's add some tests to make sure it stays that way.