### PR TITLE
Do not cast null to array

### DIFF
--- a/lib/Doctrine/Common/Annotations/DocLexer.php
+++ b/lib/Doctrine/Common/Annotations/DocLexer.php
@@ -130,9 +130,13 @@ final class DocLexer extends AbstractLexer
     }
 
     /** @return array{value: int|string, type:self::T_*|null, position:int} */
-    public function peek(): array
+    public function peek(): ?array
     {
         $token = parent::peek();
+
+        if ($token === null) {
+            return null;
+        }
 
         return (array) $token;
     }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -22,5 +22,3 @@ parameters:
 
         # That tag is empty on purpose
         - '#PHPDoc tag @var has invalid value \(\)\: Unexpected token "\*/", expected type at offset 9#'
-        # Backwards-compatibility
-        - '#^Return type.*of method.*DocLexer::peek.*should be compatible.*$#'

--- a/tests/Doctrine/Tests/Common/Annotations/DocLexerTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/DocLexerTest.php
@@ -320,4 +320,9 @@ class DocLexerTest extends TestCase
         self::assertFalse($lexer->nextTokenIsAdjacent());
         self::assertFalse($lexer->moveNext());
     }
+
+    public function testItReturnsNullWhenThereIsNothingToParse(): void
+    {
+        self::assertNull((new DocLexer())->peek());
+    }
 }


### PR DESCRIPTION
The possibility that null could be returned was overlooked in 2286f7ba1e943d3be4ce22503feac8c683e35bd5 .

Fixes #462 