### PR TITLE
Specify second template parameter

### DIFF
--- a/lib/Doctrine/Common/Annotations/DocLexer.php
+++ b/lib/Doctrine/Common/Annotations/DocLexer.php
@@ -16,7 +16,7 @@ use function substr;
 /**
  * Simple lexer for docblock annotations.
  *
- * @template-extends AbstractLexer<DocLexer::T_*>
+ * @template-extends AbstractLexer<DocLexer::T_*, string>
  */
 final class DocLexer extends AbstractLexer
 {


### PR DESCRIPTION
The by-ref `$value` parameter is modified in `DocLexer::getType()`, but not its type, which stays a string. This guarantee that the token value will always be a string:

https://github.com/doctrine/annotations/blob/9e034d7a70032d422169f27d8759e8d84abb4f51/lib/Doctrine/Common/Annotations/DocLexer.php#L104