### PR TITLE
Add supporting for a variadic parameter [2.x]

### DIFF
--- a/lib/Doctrine/Common/Annotations/DocParser.php
+++ b/lib/Doctrine/Common/Annotations/DocParser.php
@@ -607,11 +607,13 @@ final class DocParser
                     $metadata['constructor_args'][$parameter->getName()] = [
                         'position' => $parameter->getPosition(),
                     ];
-                    if (! $parameter->isVariadic()) {
-                        $metadata['constructor_args'][$parameter->getName()]['default'] = $parameter->isOptional()
-                            ? $parameter->getDefaultValue()
-                            : null;
+                    if ($parameter->isVariadic()) {
+                        continue;
                     }
+
+                    $metadata['constructor_args'][$parameter->getName()]['default'] = $parameter->isOptional()
+                        ? $parameter->getDefaultValue()
+                        : null;
                 }
             }
         }
@@ -1414,19 +1416,9 @@ EXCEPTION
 
                 switch (true) {
                     case $hasPositional && $hasNamed:
-                        // Legacy behavior
                         $value = $namedArguments[$property];
                         unset($namedArguments[$property], $positionalArguments[$position]);
                         break;
-
-                        /**
-                         * todo: remove if we need the legacy behavior that is incorrect for PHP attributes
-                         * @see \Doctrine\Tests\Common\Annotations\DocParserTest::testNamedArgumentsConstructorAnnotationWithDefaultPropertySet
-                         */
-                        // // Valid behavior
-                        // throw AnnotationException::semanticalError(
-                        //     sprintf('Named parameter $%s overwrites previous argument.', $property)
-                        // );
                     case $hasPositional:
                         $value = $positionalArguments[$position];
                         unset($positionalArguments[$position]);

--- a/lib/Doctrine/Common/Annotations/DocParser.php
+++ b/lib/Doctrine/Common/Annotations/DocParser.php
@@ -940,31 +940,7 @@ EXCEPTION
                 return $this->instantiateAnnotiation($originalName, $this->context, $name, $values);
             }
 
-            $positionalValues = [];
-            foreach (self::$annotationMetadata[$name]['constructor_args'] as $property => $parameter) {
-                $positionalValues[$parameter['position']] = $parameter['default'];
-            }
-
-            foreach ($values as $property => $value) {
-                if (! isset(self::$annotationMetadata[$name]['constructor_args'][$property])) {
-                    throw AnnotationException::creationError(sprintf(
-                        <<<'EXCEPTION'
-The annotation @%s declared on %s does not have a property named "%s"
-that can be set through its named arguments constructor.
-Available named arguments: %s
-EXCEPTION
-                        ,
-                        $originalName,
-                        $this->context,
-                        $property,
-                        implode(', ', array_keys(self::$annotationMetadata[$name]['constructor_args']))
-                    ));
-                }
-
-                $positionalValues[self::$annotationMetadata[$name]['constructor_args'][$property]['position']] = $value;
-            }
-
-            return $this->instantiateAnnotiation($originalName, $this->context, $name, $positionalValues);
+            return $this->instantiateAnnotiation($originalName, $this->context, $name, array_values($values));
         }
 
         // check if the annotation expects values via the constructor,

--- a/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
@@ -29,6 +29,7 @@ use function sprintf;
 use function ucfirst;
 
 use const PHP_EOL;
+use const PHP_VERSION_ID;
 
 class DocParserTest extends TestCase
 {
@@ -326,8 +327,6 @@ DOCBLOCK;
  */
 DOCBLOCK;
 
-        // todo: remove if we need incorrect (legacy) behavior
-        // self::expectExceptionMessage('Named parameter $name overwrites previous argument', $e->getMessage());
         $result = $parser->parse($docblock);
         self::assertCount(1, $result);
         $annot = $result[0];
@@ -1953,7 +1952,7 @@ class SomeAnnotationWithConstructorWithVariadicParam
         $this->data = $data;
     }
 
-    /** @var array */
+    /** @var mixed */
     public $data;
 
     /** @var string */

--- a/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
@@ -257,7 +257,11 @@ DOCBLOCK;
         self::assertInstanceOf(SomeAnnotationWithConstructorWithVariadicParam::class, $annot);
 
         self::assertSame('Some data', $annot->name);
-        self::assertSame(['foo' => 'Foo', 'bar' => 'Bar'], $annot->data);
+        if (PHP_VERSION_ID >= 80000) {
+            self::assertSame(['foo' => 'Foo', 'bar' => 'Bar'], $annot->data);
+        } else {
+            self::assertSame(['Foo', 'Bar'], $annot->data);
+        }
 
         // With named arguments shuffled
         $docblock = <<<'DOCBLOCK'
@@ -273,7 +277,11 @@ DOCBLOCK;
         self::assertInstanceOf(SomeAnnotationWithConstructorWithVariadicParam::class, $annot);
 
         self::assertSame('Some data', $annot->name);
-        self::assertSame(['foo' => 'Foo', 'bar' => 'Bar'], $annot->data);
+        if (PHP_VERSION_ID >= 80000) {
+            self::assertSame(['foo' => 'Foo', 'bar' => 'Bar'], $annot->data);
+        } else {
+            self::assertSame(['Foo', 'Bar'], $annot->data);
+        }
 
         // Unnamed arguments
         $docblock = <<<'DOCBLOCK'
@@ -305,7 +313,11 @@ DOCBLOCK;
         self::assertInstanceOf(SomeAnnotationWithConstructorWithVariadicParam::class, $annot);
 
         self::assertSame('Some data', $annot->name);
-        self::assertSame(['Foo', 'bar' => 'Bar'], $annot->data);
+        if (PHP_VERSION_ID >= 80000) {
+            self::assertSame(['Foo', 'bar' => 'Bar'], $annot->data);
+        } else {
+            self::assertSame(['Foo', 'Bar'], $annot->data);
+        }
 
         // With named variadic argument that conflicts with the first parameter
         $docblock = <<<'DOCBLOCK'
@@ -323,7 +335,11 @@ DOCBLOCK;
         self::assertInstanceOf(SomeAnnotationWithConstructorWithVariadicParam::class, $annot);
 
         self::assertSame('Test', $annot->name);
-        self::assertSame(['foo' => 'Foo', 'bar' => 'Bar'], $annot->data);
+        if (PHP_VERSION_ID >= 80000) {
+            self::assertSame(['foo' => 'Foo', 'bar' => 'Bar'], $annot->data);
+        } else {
+            self::assertSame(['Foo', 'Bar'], $annot->data);
+        }
     }
 
     public function testAnnotationWithoutConstructor(): void


### PR DESCRIPTION
The PR adds supporting for variadic parameters in annotations with `NamedArgumentConstructor`.  
Before this PR, the following code would throw an exception:

```php
/**
 * @Annotation
 * @NamedArgumentConstructor
 */
class SomeAnnotation
{
    public function __construct(
        private string $foo,
        private string ...$bar,
    ) {
    }
}
//  ReflectionException: Internal error: Failed to retrieve the default value
```

---

Also, I've found some strange behavior in the case when a named argument conflicts with a positional argument.
If we use the annotation from the previous example, in the following code the `$foo` parameter will have the `"bar"` value.

```php
/**
 * @SomeAnnotation('foo', foo: 'bar')
 */
```

In the case with PHP attributes, there an exception [will be thrown](https://3v4l.org/bMZhT).

I've added TODOs to improve this behavior but, I think, you will choose the legacy one.

CodeStyle will be passed after TODOs resolving.
