### PR TITLE
Ignore a variadic parameter [1.x]

### DIFF
--- a/lib/Doctrine/Common/Annotations/DocParser.php
+++ b/lib/Doctrine/Common/Annotations/DocParser.php
@@ -614,16 +614,16 @@ final class DocParser
                 $metadata['default_property'] = reset($metadata['properties']);
             } elseif ($metadata['has_named_argument_constructor']) {
                 foreach ($constructor->getParameters() as $parameter) {
-                    $metadata['constructor_args'][$parameter->getName()] = [
-                        'position' => $parameter->getPosition(),
-                    ];
                     if ($parameter->isVariadic()) {
-                        continue;
+                        break;
                     }
 
-                    $metadata['constructor_args'][$parameter->getName()]['default'] = $parameter->isOptional()
-                        ? $parameter->getDefaultValue()
-                        : null;
+                    $metadata['constructor_args'][$parameter->getName()] = [
+                        'position' => $parameter->getPosition(),
+                        'default'  => $parameter->isOptional()
+                            ? $parameter->getDefaultValue()
+                            : null,
+                    ];
                 }
             }
         }
@@ -954,10 +954,6 @@ EXCEPTION
 
             $positionalValues = [];
             foreach (self::$annotationMetadata[$name]['constructor_args'] as $property => $parameter) {
-                if (! array_key_exists('default', $parameter)) {
-                    break;
-                }
-
                 $positionalValues[$parameter['position']] = $parameter['default'];
             }
 
@@ -1446,11 +1442,6 @@ EXCEPTION
             }
 
             foreach (self::$annotationMetadata[$name]['constructor_args'] as $property => $parameter) {
-                // The parameter is variadic
-                if (!array_key_exists('default', $parameter)) {
-                    break;
-                }
-
                 if (array_key_exists($property, $namedArguments)) {
                     $values[$property] = $namedArguments[$property];
                     unset($namedArguments[$property]);

--- a/lib/Doctrine/Common/Annotations/DocParser.php
+++ b/lib/Doctrine/Common/Annotations/DocParser.php
@@ -17,7 +17,6 @@ use Throwable;
 use function array_key_exists;
 use function array_keys;
 use function array_map;
-use function array_merge;
 use function array_pop;
 use function array_values;
 use function class_exists;
@@ -956,9 +955,10 @@ EXCEPTION
 
             $positionalValues = [];
             foreach (self::$annotationMetadata[$name]['constructor_args'] as $property => $parameter) {
-                if (!array_key_exists('default', $parameter)) {
+                if (! array_key_exists('default', $parameter)) {
                     break;
                 }
+
                 $positionalValues[$parameter['position']] = $parameter['default'];
             }
 
@@ -1450,11 +1450,13 @@ EXCEPTION
                 if ($parameter['is_variadic']) {
                     break;
                 }
+
                 if (array_key_exists($property, $namedArguments)) {
                     $values[$property] = $namedArguments[$property];
                     unset($namedArguments[$property]);
                     continue;
                 }
+
                 $position = $parameter['position'];
                 if (isset($values[$property]) || ! isset($positionalArguments[$position])) {
                     continue;

--- a/lib/Doctrine/Common/Annotations/DocParser.php
+++ b/lib/Doctrine/Common/Annotations/DocParser.php
@@ -616,7 +616,6 @@ final class DocParser
                 foreach ($constructor->getParameters() as $parameter) {
                     $metadata['constructor_args'][$parameter->getName()] = [
                         'position' => $parameter->getPosition(),
-                        'is_variadic' => $parameter->isVariadic(),
                     ];
                     if ($parameter->isVariadic()) {
                         continue;
@@ -1447,7 +1446,8 @@ EXCEPTION
             }
 
             foreach (self::$annotationMetadata[$name]['constructor_args'] as $property => $parameter) {
-                if ($parameter['is_variadic']) {
+                // The parameter is variadic
+                if (!array_key_exists('default', $parameter)) {
                     break;
                 }
 

--- a/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
@@ -2010,7 +2010,7 @@ class SomeAnnotationWithConstructorWithVariadicParam
         $this->data = $data;
     }
 
-    /** @var mixed */
+    /** @var string[] */
     public $data;
 
     /** @var string */

--- a/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
@@ -31,6 +31,7 @@ use function sprintf;
 use function ucfirst;
 
 use const PHP_EOL;
+use const PHP_VERSION_ID;
 
 class DocParserTest extends TestCase
 {
@@ -223,6 +224,123 @@ DOCBLOCK;
         self::assertEquals('bar', $annot->foo);
         $marker = $result[1];
         self::assertInstanceOf(Marker::class, $marker);
+    }
+
+    public function testAnnotationWithConstructorWithVariadicParam(): void
+    {
+        $parser = $this->createTestParser();
+
+        // Without variadic arguments
+        $docblock = <<<'DOCBLOCK'
+/**
+ * @SomeAnnotationWithConstructorWithVariadicParam("Some data")
+ */
+DOCBLOCK;
+
+        $result = $parser->parse($docblock);
+        self::assertCount(1, $result);
+        $annot = $result[0];
+
+        self::assertInstanceOf(SomeAnnotationWithConstructorWithVariadicParam::class, $annot);
+
+        self::assertSame('Some data', $annot->name);
+        self::assertSame([], $annot->data);
+
+        // With named arguments
+        $docblock = <<<'DOCBLOCK'
+/**
+ * @SomeAnnotationWithConstructorWithVariadicParam(name = "Some data", foo = "Foo", bar = "Bar")
+ */
+DOCBLOCK;
+
+        $result = $parser->parse($docblock);
+        self::assertCount(1, $result);
+        $annot = $result[0];
+
+        self::assertInstanceOf(SomeAnnotationWithConstructorWithVariadicParam::class, $annot);
+
+        self::assertSame('Some data', $annot->name);
+        if (PHP_VERSION_ID >= 80000) {
+            self::assertSame(['foo' => 'Foo', 'bar' => 'Bar'], $annot->data);
+        } else {
+            self::assertSame(['Foo', 'Bar'], $annot->data);
+        }
+
+        // With named arguments shuffled
+        $docblock = <<<'DOCBLOCK'
+/**
+ * @SomeAnnotationWithConstructorWithVariadicParam(foo = "Foo", name = "Some data", bar = "Bar")
+ */
+DOCBLOCK;
+
+        $result = $parser->parse($docblock);
+        self::assertCount(1, $result);
+        $annot = $result[0];
+
+        self::assertInstanceOf(SomeAnnotationWithConstructorWithVariadicParam::class, $annot);
+
+        self::assertSame('Some data', $annot->name);
+        if (PHP_VERSION_ID >= 80000) {
+            self::assertSame(['foo' => 'Foo', 'bar' => 'Bar'], $annot->data);
+        } else {
+            self::assertSame(['Foo', 'Bar'], $annot->data);
+        }
+
+        // Unnamed arguments
+        $docblock = <<<'DOCBLOCK'
+/**
+ * @SomeAnnotationWithConstructorWithVariadicParam("Some data", "Foo", "Bar")
+ */
+DOCBLOCK;
+
+        $result = $parser->parse($docblock);
+        self::assertCount(1, $result);
+        $annot = $result[0];
+
+        self::assertInstanceOf(SomeAnnotationWithConstructorWithVariadicParam::class, $annot);
+
+        self::assertSame('Some data', $annot->name);
+        self::assertSame(['Foo', 'Bar'], $annot->data);
+
+        // With positional first and combined variadic arguments
+        $docblock = <<<'DOCBLOCK'
+/**
+ * @SomeAnnotationWithConstructorWithVariadicParam("Some data", "Foo", bar = "Bar")
+ */
+DOCBLOCK;
+
+        $result = $parser->parse($docblock);
+        self::assertCount(1, $result);
+        $annot = $result[0];
+
+        self::assertInstanceOf(SomeAnnotationWithConstructorWithVariadicParam::class, $annot);
+
+        self::assertSame('Some data', $annot->name);
+        if (PHP_VERSION_ID >= 80000) {
+            self::assertSame(['Foo', 'bar' => 'Bar'], $annot->data);
+        } else {
+            self::assertSame(['Foo', 'Bar'], $annot->data);
+        }
+
+        // With named variadic argument that conflicts with the first parameter
+        $docblock = <<<'DOCBLOCK'
+/**
+ * @SomeAnnotationWithConstructorWithVariadicParam("Some data", foo = "Foo", name = "Test", bar = "Bar")
+ */
+DOCBLOCK;
+
+        $result = $parser->parse($docblock);
+        self::assertCount(1, $result);
+        $annot = $result[0];
+
+        self::assertInstanceOf(SomeAnnotationWithConstructorWithVariadicParam::class, $annot);
+
+        self::assertSame('Test', $annot->name);
+        if (PHP_VERSION_ID >= 80000) {
+            self::assertSame(['foo' => 'Foo', 'bar' => 'Bar'], $annot->data);
+        } else {
+            self::assertSame(['Foo', 'Bar'], $annot->data);
+        }
     }
 
     public function testAnnotationWithoutConstructor(): void
@@ -1887,6 +2005,25 @@ class SomeAnnotationWithConstructorWithoutParams
     public $data;
 
     /** @var mixed */
+    public $name;
+}
+
+/**
+ * @Annotation
+ * @NamedArgumentConstructor
+ */
+class SomeAnnotationWithConstructorWithVariadicParam
+{
+    public function __construct(string $name, string ...$data)
+    {
+        $this->name = $name;
+        $this->data = $data;
+    }
+
+    /** @var mixed */
+    public $data;
+
+    /** @var string */
     public $name;
 }
 

--- a/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
@@ -31,7 +31,6 @@ use function sprintf;
 use function ucfirst;
 
 use const PHP_EOL;
-use const PHP_VERSION_ID;
 
 class DocParserTest extends TestCase
 {
@@ -228,7 +227,7 @@ DOCBLOCK;
 
     public function testAnnotationWithConstructorWithVariadicParamAndExtraNamedArguments(): void
     {
-        $parser = $this->createTestParser();
+        $parser   = $this->createTestParser();
         $docblock = <<<'DOCBLOCK'
 /**
  * @SomeAnnotationWithConstructorWithVariadicParam(name = "Some data", foo = "Foo", bar = "Bar")
@@ -250,7 +249,7 @@ DOCBLOCK;
 
     public function testAnnotationWithConstructorWithVariadicParamAndExtraNamedArgumentsShuffled(): void
     {
-        $parser = $this->createTestParser();
+        $parser   = $this->createTestParser();
         $docblock = <<<'DOCBLOCK'
 /**
  * @SomeAnnotationWithConstructorWithVariadicParam(foo = "Foo", name = "Some data", bar = "Bar")
@@ -265,8 +264,7 @@ DOCBLOCK;
 
     public function testAnnotationWithConstructorWithVariadicParamAndCombinedNamedAndPositionalArguments(): void
     {
-        $parser = $this->createTestParser();
-        // With positional first and combined variadic arguments
+        $parser   = $this->createTestParser();
         $docblock = <<<'DOCBLOCK'
 /**
  * @SomeAnnotationWithConstructorWithVariadicParam("Some data", "Foo", bar = "Bar")
@@ -276,12 +274,12 @@ DOCBLOCK;
         self::expectException(AnnotationException::class);
         self::expectExceptionMessage('The annotation constructor has no supported parameter $bar');
 
-        $result = $parser->parse($docblock);
+        $parser->parse($docblock);
     }
 
     public function testAnnotationWithConstructorWithVariadicParamPassOneNamedArgument(): void
     {
-        $parser = $this->createTestParser();
+        $parser   = $this->createTestParser();
         $docblock = <<<'DOCBLOCK'
 /**
  * @SomeAnnotationWithConstructorWithVariadicParam(name = "Some data", data = "Foo")
@@ -296,7 +294,7 @@ DOCBLOCK;
 
     public function testAnnotationWithConstructorWithVariadicParamPassPositionalArguments(): void
     {
-        $parser = $this->createTestParser();
+        $parser   = $this->createTestParser();
         $docblock = <<<'DOCBLOCK'
 /**
  * @SomeAnnotationWithConstructorWithVariadicParam("Some data", "Foo", "Bar")


### PR DESCRIPTION
The PR adds supporting for variadic parameters in annotations with `NamedArgumentConstructor`.

See #472