### PR TITLE
Update branch metadata for documentation

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -5,21 +5,25 @@
     "docsSlug": "doctrine-annotations",
     "versions": [
         {
-            "name": "1.14",
-            "branchName": "1.14.x",
-            "slug": "latest",
-            "upcoming": true
-        },
-        {
-            "name": "1.13",
-            "branchName": "1.13.x",
-            "slug": "1.13",
+            "name": "2.0",
+            "branchName": "2.0.x",
             "aliases": [
                 "current",
                 "stable"
             ],
             "current": true,
             "maintained": true
+        },
+        {
+            "name": "1.14",
+            "branchName": "1.14.x",
+            "maintained": true
+        },
+        {
+            "name": "1.13",
+            "branchName": "1.13.x",
+            "slug": "1.13",
+            "maintained": false
         },
         {
             "name": "1.12",


### PR DESCRIPTION
Note that there is no 2.1.x branch yet, and there might never be a need for one if we are lucky.

Fixes https://github.com/doctrine/annotations/issues/476