### PR TITLE
Allow annotation classes with a variadic parameter

### DIFF
--- a/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
@@ -1644,6 +1644,18 @@ DOCBLOCK;
         self::assertSame(1234, $result[0]->getBar());
     }
 
+    public function testNamedArgumentsConstructorInterfaceWithExtraArguments(): void
+    {
+        $docParser = $this->createTestParser();
+
+        $this->expectException(AnnotationException::class);
+        $this->expectExceptionMessageMatches(
+            '/does not have a property named "invalid"\s.*\sAvailable named arguments: foo, bar/'
+        );
+
+        $docParser->parse('/** @NamedAnnotation(foo="baz", invalid="uh oh") */');
+    }
+
     public function testNamedArgumentsConstructorAnnotation(): void
     {
         $result = $this
@@ -1690,6 +1702,18 @@ DOCBLOCK;
         self::assertInstanceOf(AnotherNamedAnnotation::class, $result[0]);
         self::assertSame('baz', $result[0]->getFoo());
         self::assertSame(1234, $result[0]->getBar());
+    }
+
+    public function testNamedArgumentsConstructorAnnotationWithExtraArguments(): void
+    {
+        $docParser = $this->createTestParser();
+
+        $this->expectException(AnnotationException::class);
+        $this->expectExceptionMessageMatches(
+            '/does not have a property named "invalid"\s.*\sAvailable named arguments: foo, bar/'
+        );
+
+        $docParser->parse('/** @AnotherNamedAnnotation(foo="baz", invalid="uh oh") */');
     }
 
     public function testNamedArgumentsConstructorAnnotationWithDefaultPropertyAsArray(): void
@@ -1742,6 +1766,115 @@ DOCBLOCK;
 
             throw $exc;
         }
+    }
+
+    public function testAnnotationWithConstructorWithVariadicParamAndExtraNamedArguments(): void
+    {
+        $parser   = $this->createTestParser();
+        $docblock = <<<'DOCBLOCK'
+/**
+ * @SomeAnnotationWithConstructorWithVariadicParam(name = "Some data", foo = "Foo", bar = "Bar")
+ */
+DOCBLOCK;
+
+        $this->expectException(AnnotationException::class);
+        $this->expectExceptionMessageMatches(
+            '/does not have a property named "foo"\s.*\sAvailable named arguments: name/'
+        );
+
+        $parser->parse($docblock);
+    }
+
+    public function testAnnotationWithConstructorWithVariadicParamAndExtraNamedArgumentsShuffled(): void
+    {
+        $parser   = $this->createTestParser();
+        $docblock = <<<'DOCBLOCK'
+/**
+ * @SomeAnnotationWithConstructorWithVariadicParam(foo = "Foo", name = "Some data", bar = "Bar")
+ */
+DOCBLOCK;
+
+        $this->expectException(AnnotationException::class);
+        $this->expectExceptionMessageMatches(
+            '/does not have a property named "foo"\s.*\sAvailable named arguments: name/'
+        );
+
+        $parser->parse($docblock);
+    }
+
+    public function testAnnotationWithConstructorWithVariadicParamAndCombinedNamedAndPositionalArguments(): void
+    {
+        $parser   = $this->createTestParser();
+        $docblock = <<<'DOCBLOCK'
+/**
+ * @SomeAnnotationWithConstructorWithVariadicParam("Some data", "Foo", bar = "Bar")
+ */
+DOCBLOCK;
+
+        $this->expectException(AnnotationException::class);
+        $this->expectExceptionMessageMatches(
+            '/does not have a property named "bar"\s.*\sAvailable named arguments: name/'
+        );
+
+        $parser->parse($docblock);
+    }
+
+    public function testAnnotationWithConstructorWithVariadicParamPassOneNamedArgument(): void
+    {
+        $parser   = $this->createTestParser();
+        $docblock = <<<'DOCBLOCK'
+/**
+ * @SomeAnnotationWithConstructorWithVariadicParam(name = "Some data", data = "Foo")
+ */
+DOCBLOCK;
+
+        $this->expectException(AnnotationException::class);
+        $this->expectExceptionMessageMatches(
+            '/does not have a property named "data"\s.*\sAvailable named arguments: name/'
+        );
+
+        $parser->parse($docblock);
+    }
+
+    public function testAnnotationWithConstructorWithVariadicParamPassPositionalArguments(): void
+    {
+        $parser   = $this->createTestParser();
+        $docblock = <<<'DOCBLOCK'
+/**
+ * @SomeAnnotationWithConstructorWithVariadicParam("Some data", "Foo", "Bar")
+ */
+DOCBLOCK;
+
+        $result = $parser->parse($docblock);
+        self::assertCount(1, $result);
+        $annot = $result[0];
+
+        self::assertInstanceOf(SomeAnnotationWithConstructorWithVariadicParam::class, $annot);
+
+        self::assertSame('Some data', $annot->name);
+        // Positional extra arguments will be ignored
+        self::assertSame([], $annot->data);
+    }
+
+    public function testAnnotationWithConstructorWithVariadicParamNoArgs(): void
+    {
+        $parser = $this->createTestParser();
+
+        // Without variadic arguments
+        $docblock = <<<'DOCBLOCK'
+/**
+ * @SomeAnnotationWithConstructorWithVariadicParam("Some data")
+ */
+DOCBLOCK;
+
+        $result = $parser->parse($docblock);
+        self::assertCount(1, $result);
+        $annot = $result[0];
+
+        self::assertInstanceOf(SomeAnnotationWithConstructorWithVariadicParam::class, $annot);
+
+        self::assertSame('Some data', $annot->name);
+        self::assertSame([], $annot->data);
     }
 
     /**
@@ -1848,6 +1981,25 @@ class NamedAnnotationWithArray
     {
         return $this->bar;
     }
+}
+
+/**
+ * @Annotation
+ * @NamedArgumentConstructor
+ */
+class SomeAnnotationWithConstructorWithVariadicParam
+{
+    public function __construct(string $name, string ...$data)
+    {
+        $this->name = $name;
+        $this->data = $data;
+    }
+
+    /** @var string[] */
+    public $data;
+
+    /** @var string */
+    public $name;
 }
 
 /** @Annotation */


### PR DESCRIPTION
Replaces #473.

This PR follows a simpler approach to fix the issue that #473 and #472 attempted to address: If an annotation class has a variadic parameter, the parser should not fail with a reflection exception.

The variadic parameter is still not accessible though, it's simply being ignored. As discussed in #472, we don't want to introduce support for variadics as a new feature. Furthermore, there is no portable way to pass named arguments to a variadic parameter that would work on PHP 7.4.