### PR TITLE
Checking if the reflection is anonymous before parsing file tokens

### DIFF
--- a/lib/Doctrine/Common/Annotations/PhpParser.php
+++ b/lib/Doctrine/Common/Annotations/PhpParser.php
@@ -43,6 +43,11 @@ final class PhpParser
             return $reflection->getUseStatements();
         }
 
+        // we can't rely on the file's namespaces when the class is anonymous
+        if ($reflection->isAnonymous()) {
+            return [];
+        }
+
         $filename = $reflection->getFileName();
 
         if ($filename === false) {


### PR DESCRIPTION
Resolves #490

This Pull Request aims to solve #490 by bypassing the tokenizer when an anonymous class is received, because the current logic only supports normal classes declared inside a namespaced file.