### PR TITLE
Fix filemtime() warning because of eval'd code

### DIFF
--- a/lib/Doctrine/Common/Annotations/CachedReader.php
+++ b/lib/Doctrine/Common/Annotations/CachedReader.php
@@ -230,7 +230,7 @@ final class CachedReader implements Reader
         $parent = $class->getParentClass();
 
         $lastModification =  max(array_merge(
-            [is_file($filename) ? filemtime($filename) : 0],
+            [$filename !== false && is_file($filename) ? filemtime($filename) : 0],
             array_map(function (ReflectionClass $reflectionTrait): int {
                 return $this->getTraitLastModificationTime($reflectionTrait);
             }, $class->getTraits()),
@@ -254,7 +254,7 @@ final class CachedReader implements Reader
         }
 
         $lastModificationTime = max(array_merge(
-            [is_file($fileName) ? filemtime($fileName) : 0],
+            [$fileName !== false && is_file($fileName) ? filemtime($fileName) : 0],
             array_map(function (ReflectionClass $reflectionTrait): int {
                 return $this->getTraitLastModificationTime($reflectionTrait);
             }, $reflectionTrait->getTraits())

--- a/lib/Doctrine/Common/Annotations/CachedReader.php
+++ b/lib/Doctrine/Common/Annotations/CachedReader.php
@@ -11,6 +11,7 @@ use function array_map;
 use function array_merge;
 use function assert;
 use function filemtime;
+use function is_file;
 use function max;
 use function time;
 
@@ -229,7 +230,7 @@ final class CachedReader implements Reader
         $parent = $class->getParentClass();
 
         $lastModification =  max(array_merge(
-            [$filename ? filemtime($filename) : 0],
+            [is_file($filename) ? filemtime($filename) : 0],
             array_map(function (ReflectionClass $reflectionTrait): int {
                 return $this->getTraitLastModificationTime($reflectionTrait);
             }, $class->getTraits()),
@@ -253,7 +254,7 @@ final class CachedReader implements Reader
         }
 
         $lastModificationTime = max(array_merge(
-            [$fileName ? filemtime($fileName) : 0],
+            [is_file($fileName) ? filemtime($fileName) : 0],
             array_map(function (ReflectionClass $reflectionTrait): int {
                 return $this->getTraitLastModificationTime($reflectionTrait);
             }, $reflectionTrait->getTraits())

--- a/lib/Doctrine/Common/Annotations/PsrCachedReader.php
+++ b/lib/Doctrine/Common/Annotations/PsrCachedReader.php
@@ -12,6 +12,7 @@ use function array_map;
 use function array_merge;
 use function assert;
 use function filemtime;
+use function is_file;
 use function max;
 use function rawurlencode;
 use function time;
@@ -195,7 +196,7 @@ final class PsrCachedReader implements Reader
         $parent = $class->getParentClass();
 
         $lastModification =  max(array_merge(
-            [$filename ? filemtime($filename) : 0],
+            [is_file($filename) ? filemtime($filename) : 0],
             array_map(function (ReflectionClass $reflectionTrait): int {
                 return $this->getTraitLastModificationTime($reflectionTrait);
             }, $class->getTraits()),
@@ -219,7 +220,7 @@ final class PsrCachedReader implements Reader
         }
 
         $lastModificationTime = max(array_merge(
-            [$fileName ? filemtime($fileName) : 0],
+            [is_file($fileName) ? filemtime($fileName) : 0],
             array_map(function (ReflectionClass $reflectionTrait): int {
                 return $this->getTraitLastModificationTime($reflectionTrait);
             }, $reflectionTrait->getTraits())

--- a/lib/Doctrine/Common/Annotations/PsrCachedReader.php
+++ b/lib/Doctrine/Common/Annotations/PsrCachedReader.php
@@ -196,7 +196,7 @@ final class PsrCachedReader implements Reader
         $parent = $class->getParentClass();
 
         $lastModification =  max(array_merge(
-            [is_file($filename) ? filemtime($filename) : 0],
+            [$filename !== false && is_file($filename) ? filemtime($filename) : 0],
             array_map(function (ReflectionClass $reflectionTrait): int {
                 return $this->getTraitLastModificationTime($reflectionTrait);
             }, $class->getTraits()),
@@ -220,7 +220,7 @@ final class PsrCachedReader implements Reader
         }
 
         $lastModificationTime = max(array_merge(
-            [is_file($fileName) ? filemtime($fileName) : 0],
+            [$fileName !== false && is_file($fileName) ? filemtime($fileName) : 0],
             array_map(function (ReflectionClass $reflectionTrait): int {
                 return $this->getTraitLastModificationTime($reflectionTrait);
             }, $reflectionTrait->getTraits())

--- a/tests/Doctrine/Tests/Common/Annotations/CachedReaderTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/CachedReaderTest.php
@@ -236,7 +236,7 @@ namespace Doctrine\Tests\Common\Annotations;
 /**
  * @\Doctrine\Tests\Common\Annotations\Fixtures\AnnotationTargetClass("Some data")
  */
-class PsrEvalClass {
+class CachedEvalClass {
 
 }
 EOS;
@@ -248,7 +248,7 @@ EOS;
 
         $reader = new CachedReader(new AnnotationReader(), $cache, true);
         // @phpstan-ignore class.notFound
-        $readAnnotations = $reader->getClassAnnotations(new ReflectionClass(PsrEvalClass::class));
+        $readAnnotations = $reader->getClassAnnotations(new ReflectionClass(CachedEvalClass::class));
 
         self::assertCount(1, $readAnnotations);
     }

--- a/tests/Doctrine/Tests/Common/Annotations/PsrCachedReaderTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/PsrCachedReaderTest.php
@@ -220,6 +220,27 @@ final class PsrCachedReaderTest extends AbstractReaderTest
         );
     }
 
+    public function testReaderDoesNotCacheIfFileDoesNotExistSoLastModificationCannotBeDetermined(): void
+    {
+        $code = <<<'EOS'
+namespace Doctrine\Tests\Common\Annotations;
+
+/**
+ * @\Doctrine\Tests\Common\Annotations\Fixtures\AnnotationTargetClass("Some data")
+ */
+class PsrEvalClass {
+
+}
+EOS;
+
+        eval($code);
+
+        $readAnnotations = (new PsrCachedReader(new AnnotationReader(), new ArrayAdapter(), true))
+            ->getClassAnnotations(new ReflectionClass(PsrEvalClass::class));
+
+        self::assertCount(1, $readAnnotations);
+    }
+
     protected function doTestCacheStale(string $className, int $lastCacheModification): PsrCachedReader
     {
         $cacheKey = rawurlencode($className);

--- a/tests/Doctrine/Tests/Common/Annotations/PsrCachedReaderTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/PsrCachedReaderTest.php
@@ -228,7 +228,7 @@ namespace Doctrine\Tests\Common\Annotations;
 /**
  * @\Doctrine\Tests\Common\Annotations\Fixtures\AnnotationTargetClass("Some data")
  */
-class PsrEvalClass {
+class PsrCachedEvalClass {
 
 }
 EOS;
@@ -237,7 +237,7 @@ EOS;
 
         $reader = new PsrCachedReader(new AnnotationReader(), new ArrayAdapter(), true);
         // @phpstan-ignore class.notFound
-        $readAnnotations = $reader->getClassAnnotations(new ReflectionClass(PsrEvalClass::class));
+        $readAnnotations = $reader->getClassAnnotations(new ReflectionClass(PsrCachedEvalClass::class));
 
         self::assertCount(1, $readAnnotations);
     }

--- a/tests/Doctrine/Tests/Common/Annotations/PsrCachedReaderTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/PsrCachedReaderTest.php
@@ -235,6 +235,7 @@ EOS;
 
         eval($code);
 
+        // @phpstan-ignore class.notFound
         $readAnnotations = (new PsrCachedReader(new AnnotationReader(), new ArrayAdapter(), true))
             ->getClassAnnotations(new ReflectionClass(PsrEvalClass::class));
 

--- a/tests/Doctrine/Tests/Common/Annotations/PsrCachedReaderTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/PsrCachedReaderTest.php
@@ -235,9 +235,9 @@ EOS;
 
         eval($code);
 
+        $reader = new PsrCachedReader(new AnnotationReader(), new ArrayAdapter(), true);
         // @phpstan-ignore class.notFound
-        $readAnnotations = (new PsrCachedReader(new AnnotationReader(), new ArrayAdapter(), true))
-            ->getClassAnnotations(new ReflectionClass(PsrEvalClass::class));
+        $readAnnotations = $reader->getClassAnnotations(new ReflectionClass(PsrEvalClass::class));
 
         self::assertCount(1, $readAnnotations);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 1.14.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Ticket       | Fix [#492](https://github.com/doctrine/annotations/issues/492)
| License       | MIT
| Doc PR        |  -

#### Description

This small PR fix the old problem "`filemtime()` warning on eval'd code" described in issue [#492](https://github.com/doctrine/annotations/issues/492) and in PR [#436](https://github.com/doctrine/annotations/pull/436).

I faced this bug in my current big project when upgrading PHP from 8.1 to 8.2. But I can't migrate away from doctrine/annotations and use attributes just now. So, please, check and accept this PR ASAP. Thank you!
