### PR TITLE
Ignore complaints about dead code 

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -15,4 +15,12 @@
             <directory name="vendor" />
         </ignoreFiles>
     </projectFiles>
+    <issueHandlers>
+        <NoValue>
+            <errorLevel type="suppress">
+                <file name="lib/Doctrine/Common/Annotations/Annotation/Enum.php" />
+                <file name="lib/Doctrine/Common/Annotations/Annotation/Target.php" />
+            </errorLevel>
+        </NoValue>
+    </issueHandlers>
 </psalm>


### PR DESCRIPTION
~In the code of these constructors, we are checking the type of the 'value' property of the '$values' array.
Let us reflect the fact that we are not assuming the type in the phpdoc. I think this is OK because since both of these classes are used as Doctrine annotations, there is no way for such precise types to be useful for the end user anyway. I chose that over creating a baseline for a project that does not have one yet.~



We've declared types in phpdoc, but they are not enforced by type
declarations, so we are enforcing them with checks. Psalm complains it
is dead code because it assumes the types can be trusted.

This addresses a Psalm issue I spotted while reviewing #494