### PR TITLE
Stop maintaining 1.x

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -17,7 +17,7 @@
         {
             "name": "1.14",
             "branchName": "1.14.x",
-            "maintained": true
+            "maintained": false
         },
         {
             "name": "1.13",


### PR DESCRIPTION
This should make the maintenance of this package even more minimal than it currently is. No more merge-ups.

If we are OK with this we should delete 1.14.5 from https://github.com/doctrine/annotations/milestones