### PR TITLE
Fix a minor typo in the documentation of custom annotations

### DIFF
--- a/docs/en/custom.rst
+++ b/docs/en/custom.rst
@@ -137,7 +137,7 @@ type is applicable. Then you could define one or more targets:
 -  ``CLASS`` Allowed in class docblocks
 -  ``PROPERTY`` Allowed in property docblocks
 -  ``METHOD`` Allowed in the method docblocks
--  ``FUNCTION`` Allowed in function dockblocks
+-  ``FUNCTION`` Allowed in function docblocks
 -  ``ALL`` Allowed in class, property, method and function docblocks
 -  ``ANNOTATION`` Allowed inside other annotations
 


### PR DESCRIPTION
I noticed this minor typo (`dockblocks` instead of `docblocks`) and just wanted to fix it.